### PR TITLE
Plans and product for API version >= 2018-02-05

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -917,6 +917,55 @@ class Plan(StripeObject):
         self.statement_descriptor = statement_descriptor
 
 
+class Product(StripeObject):
+    object = 'product'
+    _id_prefix = 'prod_'
+
+    # Save built-in keyword `type`, because the `type` property will
+    # override it:
+    _type = type
+
+    def __init__(self, name=None, type=None, active=True, caption=None,
+                 description=None, attributes=None, shippable=True, url=None,
+                 statement_descriptor=None, metadata=None, **kwargs):
+        if kwargs:
+            raise UserError(400, 'Unexpected ' + ', '.join(kwargs.keys()))
+
+        try:
+            assert self._type(name) is str and name
+            assert type in ('good', 'service')
+            assert self._type(active) is bool
+            if caption is not None:
+                assert self._type(caption) is str
+            if description is not None:
+                assert self._type(description) is str
+            if attributes is not None:
+                assert self._type(attributes) is list
+                assert all(self._type(a) is str for a in attributes)
+            assert self._type(shippable) is bool
+            if url is not None:
+                assert self._type(url) is str
+            if statement_descriptor is not None:
+                assert self._type(statement_descriptor) is str
+                assert len(statement_descriptor) <= 22
+        except AssertionError:
+            raise UserError(400, 'Bad request')
+
+        # All exceptions must be raised before this point.
+        super().__init__()
+
+        self.name = name
+        self.type = type
+        self.active = active
+        self.caption = caption
+        self.description = description
+        self.attributes = attributes
+        self.shippable = shippable
+        self.url = url
+        self.statement_descriptor = statement_descriptor
+        self.metadata = metadata or {}
+
+
 class Refund(StripeObject):
     object = 'refund'
     _id_prefix = 're_'

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -25,8 +25,8 @@ import socket
 from aiohttp import web
 
 from .resources import Card, Charge, Coupon, Customer, Invoice, InvoiceItem, \
-                       Plan, Refund, Subscription, SubscriptionItem, Token, \
-                       extra_apis, store
+                       Plan, Product, Refund, Subscription, SubscriptionItem, \
+                       Token, extra_apis, store
 from .errors import UserError
 from .webhooks import register_webhook
 
@@ -242,8 +242,8 @@ for method, url, func in extra_apis:
     app.router.add_route(method, url, api_extra(func, url))
 
 
-for cls in (Card, Charge, Coupon, Customer, Invoice, InvoiceItem, Plan, Refund,
-            Subscription, SubscriptionItem, Token):
+for cls in (Card, Charge, Coupon, Customer, Invoice, InvoiceItem, Plan,
+            Product, Refund, Subscription, SubscriptionItem, Token):
     for method, url, func in (
             ('POST', '/v1/' + cls.object + 's', api_create),
             ('GET', '/v1/' + cls.object + 's/{id}', api_retrieve),

--- a/test.sh
+++ b/test.sh
@@ -23,7 +23,7 @@ cus=$(curl -sSf -u $SK: $HOST/v1/customers \
 
 curl -sSf -u $SK: $HOST/v1/plans \
    -d id=basique-mensuel \
-   -d name='Abonnement basique (mensuel)' \
+   -d product[name]='Abonnement basique (mensuel)' \
    -d amount=2500 \
    -d currency=eur \
    -d interval=month
@@ -37,14 +37,15 @@ curl -sSf -u $SK: $HOST/v1/plans \
 
 curl -sSf -u $SK: $HOST/v1/plans \
    -d id=pro-annuel \
-   -d name='Abonnement PRO (annuel)' \
+   -d product[name]='Abonnement PRO (annuel)' \
+   -d product[statement_descriptor]='abonnement pro' \
    -d amount=30000 \
    -d currency=eur \
    -d interval=year
 
 curl -sSf -u $SK: $HOST/v1/plans \
    -d id=delete-me \
-   -d name='Delete me' \
+   -d product[name]='Delete me' \
    -d amount=30000 \
    -d currency=eur \
    -d interval=year

--- a/test.sh
+++ b/test.sh
@@ -59,6 +59,13 @@ code=$(curl -so /dev/null -w '%{http_code}' -u $SK: \
             $HOST/v1/plans?doesnotexist=1)
 [ "$code" -eq 400 ]
 
+curl -sSf -u $SK: $HOST/v1/products \
+     -d name=T-shirt \
+     -d type=good \
+     -d description='Comfortable cotton t-shirt' \
+     -d attributes[]=size \
+     -d attributes[]=gender
+
 curl -sSf -u $SK: $HOST/v1/coupons \
    -d id=PARRAIN \
    -d percent_off=30 \


### PR DESCRIPTION
#### fix(server): Handle requests with multiple `key[]=item1`, `key[]=item2`

For example:

    curl -u sk_test_abcd: https://api.stripe.com/v1/products \
         -d attributes[]=size \
         -d attributes[]=gender

---

#### feat(products): Implement products

---

#### refactor(plans): Connect plans to products

See the change in Stripe API version 2018-02-05:

> Each plan object is now linked to a product object with type=service.
> The plan object fields statement_descriptor and name attributes have
> been moved to product objects.

https://stripe.com/docs/upgrades#2018-02-05
