### PR TITLE
fix(Stripe.js): Issue request to fake server, not localhost

### DIFF
--- a/localstripe/fake-stripe-v3.js
+++ b/localstripe/fake-stripe-v3.js
@@ -15,6 +15,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// First, get the domain from which this script is pulled:
+const LOCALSTRIPE_SOURCE = (function () {
+  const scripts = document.getElementsByTagName('script');
+  const src = scripts[scripts.length - 1].src;
+  return src.match(/https?:\/\/[^\/]*/)[0];
+})();
+
 // Check and warn if the real Stripe is already used in webpage
 (function () {
   var iframes = document.getElementsByTagName('iframe');
@@ -134,7 +141,7 @@ Stripe = (apiKey) => {
         body.push('payment_user_agent=localstripe');
         body = body.join('&');
 
-        req.open('POST', 'http://localhost:{{ PORT }}/v1/tokens', true);
+        req.open('POST', `${LOCALSTRIPE_SOURCE}/v1/tokens`, true);
         req.setRequestHeader('Content-Type',
                              'application/x-www-form-urlencoded');
         req.send(body);
@@ -164,7 +171,7 @@ Stripe = (apiKey) => {
         };
         source.key = apiKey;
         source.payment_user_agent = 'localstripe';
-        req.open('POST', 'http://localhost:{{ PORT }}/v1/sources', true);
+        req.open('POST', `${LOCALSTRIPE_SOURCE}/v1/sources`, true);
         req.send(JSON.stringify(source));
       });
     },
@@ -174,4 +181,4 @@ Stripe = (apiKey) => {
 
 console.log('localstripe: The Stripe object was just replaced in the page. ' +
             'Stripe elements created from now on will be fake ones, ' +
-            'communicating with the mock server.');
+            `communicating with the mock server at ${LOCALSTRIPE_SOURCE}.`);

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -259,13 +259,10 @@ for cls in (Charge, Coupon, Customer, Invoice, InvoiceItem, Plan, Product,
         app.router.add_route(method, url, func(cls, url))
 
 
-PORT = None
-
-
 def fake_stripe_js(request):
     path = os.path.dirname(os.path.realpath(__file__)) + '/fake-stripe-v3.js'
     with open(path) as f:
-        return web.Response(text=f.read().replace('{{ PORT }}', str(PORT)),
+        return web.Response(text=f.read(),
                             content_type='application/javascript')
 
 
@@ -287,8 +284,6 @@ app.router.add_post('/_config/webhooks/{id}', config_webhook)
 
 
 def start():
-    global PORT
-
     parser = argparse.ArgumentParser()
     parser.add_argument('--port', type=int, default=8420)
     parser.add_argument('--from-scratch', action='store_true')
@@ -297,11 +292,10 @@ def start():
     if not args.from_scratch:
         store.try_load_from_disk()
 
-    PORT = args.port
     # Listen on both IPv4 and IPv6
     sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.bind(('::', PORT))
+    sock.bind(('::', args.port))
 
     logger = logging.getLogger('aiohttp.access')
     logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
Before, the injected fake Stripe JS lib sent requests to
`localhost:PORT`, with `PORT` read from configuration. But when the
server was not accessed from `localhost`, requests from the web page
(add a card, add a SEPA number...) failed because `localhost:PORT` was
not available.

Now, the localstripe server URL is infered from where the JS script is
loaded. For example, if the web page contains:

    <script src="http://somehost:6666/js.stripe.com/v3/"></script>

... then calls will be made to:

    http://somehost:6666/v1/tokens
    http://somehost:6666/v1/sources