### PR TITLE
Add /_config/store route to flush data from store.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -209,6 +209,19 @@ Only those events types are currently supported:
 - Subscription: ``customer.subscription.created`` and ``customer.subscription.deleted``
 - Invoice: ``invoice.created``, ``invoice.payment_succeeded`` and ``invoice.payment_failed``
 
+Flush stored data
+-----------------
+
+Flushing data programmatically can be useful to reset localstripe if your are
+using it with any test framework.
+
+Flushing stored data can be performed using the ``/_config/data`` route
+with DELETE http method:
+
+.. code:: shell
+
+ curl -X DELETE localhost:8420/_config/data
+
 Hacking and contributing
 ------------------------
 

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -282,7 +282,13 @@ async def config_webhook(request):
     return web.Response()
 
 
+async def flush_store(request):
+    store.clear()
+    return web.Response()
+
+
 app.router.add_post('/_config/webhooks/{id}', config_webhook)
+app.router.add_delete('/_config/data', flush_store)
 
 
 def start():


### PR DESCRIPTION
Introducing new /_config/store route.
Requesting with method DELETE on it would flush all store data.

This is very useful for me to remove all localstripe data between two integration test.

Edit: squashed