### PR TITLE
Add product.created and plan.created webhooks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -199,11 +199,14 @@ Register a webhook using the special ``/_config`` route:
  curl localhost:8420/_config/webhooks/mywebhook1 \
       -d url=http://localhost:8888/api/url -d secret=whsec_s3cr3t
 
-Then, localstripe will send webhooks to this url. Only a few event types are
-currently supported (these include ``customer.created``, ``customer.updated``,
-``customer.deleted``, ``customer.source.created``, 
-``customer.subscription.created``, ``customer.subscription.deleted``
-``invoice.created``, ``invoice.payment_succeeded``, ``invoice.payment_failed``).
+Then, localstripe will send webhooks to this url.
+Only those events types are currently supported:
+- Product: ``product.created``
+- Plan: ``plan.created``
+- Customer: ``customer.created``, ``customer.updated`` and ``customer.deleted``
+- Source: ``customer.source.created``
+- Subscription: ``customer.subscription.created`` and ``customer.subscription.deleted``
+- Invoice: ``invoice.created``, ``invoice.payment_succeeded`` and ``invoice.payment_failed``
 
 Hacking and contributing
 ------------------------

--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,7 @@ Register a webhook using the special ``/_config`` route:
 
 Then, localstripe will send webhooks to this url.
 Only those events types are currently supported:
+
 - Product: ``product.created``
 - Plan: ``plan.created``
 - Customer: ``customer.created``, ``customer.updated`` and ``customer.deleted``

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1030,6 +1030,8 @@ class Plan(StripeObject):
         self.trial_period_days = trial_period_days
         self.nickname = nickname
 
+        schedule_webhook(Event('plan.created', self))
+
     @property
     def name(self):  # Support Stripe API <= 2018-02-05
         return Product._api_retrieve(self.product).name
@@ -1086,6 +1088,8 @@ class Product(StripeObject):
         self.url = url
         self.statement_descriptor = statement_descriptor
         self.metadata = metadata or {}
+
+        schedule_webhook(Event('product.created', self))
 
 
 class Refund(StripeObject):


### PR DESCRIPTION
Those one works perfectly in my integration tests.

I am using dj-stripe and Products are created in dj-stripe models accordingly.

For plans, it requires to add support to 'usage_type' attribute of stripe plans.
As I've already done this in my fork I'll submit it in another PR.