### PR TITLE
fix(expand): Don't crash when expanding a null value

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -202,10 +202,11 @@ class StripeObject(object):
             else:
                 k, path = path.split('.', 1) if '.' in path else (path, None)
                 if path is None:
-                    id = obj[k]
-                    assert type(id) is str
-                    cls = StripeObject._get_class_for_id(id)
-                    obj[k] = cls._api_retrieve(id)._export()
+                    if obj[k] is not None:
+                        id = obj[k]
+                        assert type(id) is str
+                        cls = StripeObject._get_class_for_id(id)
+                        obj[k] = cls._api_retrieve(id)._export()
                 else:
                     do_expand(path, obj[k])
         try:


### PR DESCRIPTION
For instance a query like this should return `null` as `default_source`:

    GET /v1/customers/cus_9qtQ75leoBAi7o?expand[]=default_source

Previously, it crashed. Let's also add a test to make sure it doesn't
happen again.

Closes https://github.com/adrienverge/localstripe/issues/32.