### PR TITLE
Generate plan ids when not given upon creation

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1023,6 +1023,7 @@ class List(StripeObject):
 
 class Plan(StripeObject):
     object = 'plan'
+    _id_prefix = 'plan_'
 
     def __init__(self, id=None, metadata=None, amount=None, product=None,
                  currency=None, interval=None, interval_count=1,
@@ -1043,7 +1044,7 @@ class Plan(StripeObject):
         interval_count = try_convert_to_int(interval_count)
         trial_period_days = try_convert_to_int(trial_period_days)
         try:
-            assert type(id) is str and id
+            assert id is None or type(id) is str and id
             assert type(active) is bool
             assert type(amount) is int and amount >= 0
             assert type(currency) is str and currency

--- a/test.sh
+++ b/test.sh
@@ -44,6 +44,13 @@ curl -sSf -u $SK: $HOST/v1/plans \
    -d interval=year
 
 curl -sSf -u $SK: $HOST/v1/plans \
+   -d product[name]='Without id' \
+   -d product[statement_descriptor]='Without id' \
+   -d amount=30000 \
+   -d currency=eur \
+   -d interval=year
+
+curl -sSf -u $SK: $HOST/v1/plans \
    -d id=delete-me \
    -d product[name]='Delete me' \
    -d amount=30000 \


### PR DESCRIPTION
`id`s are no longer required to create plans since the release of products. 
In this PR I'm changing the behaviour to replicate what the Stripe API does: allow `id`s to be sent optionally, and when not provided generate them with the common pattern `plan_` + unique alphanumeric suffix

This should solve point 2 @nrobates [raised](https://github.com/adrienverge/localstripe/issues/44#issuecomment-455380984)