### PR TITLE
fix(Invoice): Update properties with 'status'

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -637,11 +637,9 @@ class Invoice(StripeObject):
         self.application_fee = None
         self.attempt_count = 1
         self.attempted = True
-        self.closed = True
         self.description = description
         self.discount = None
         self.ending_balance = 0
-        self.forgiven = False
         self.receipt_number = None
         self.starting_balance = 0
         self.statement_descriptor = None
@@ -704,10 +702,14 @@ class Invoice(StripeObject):
             return self.date
 
     @property
-    def paid(self):
-        if self._charge is not None:
-            return Charge._api_retrieve(self._charge).paid
-        return not self._upcoming
+    def status(self):
+        if self._upcoming:
+            return 'draft'
+        if self._charge and Charge._api_retrieve(self._charge).paid:
+            return 'paid'
+        if self.total <= 0:
+            return 'paid'
+        return 'open'
 
     @property
     def charge(self):


### PR DESCRIPTION
Since Stripe API version 2018-11-08:
- `paid`, `closed` and `forgiven` have been removed from `Invoice`,
- `status` has been added, it can be `draft`, `open`, `paid`, `void`, or
  `uncollectible`.

https://stripe.com/docs/billing/migration/invoice-states#status