### PR TITLE
Implement tax rates

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1616,6 +1616,42 @@ class TaxId(StripeObject):
         self.verification = {'status': 'pending'}
 
 
+class TaxRate(StripeObject):
+    object = 'tax_rate'
+    _id_prefix = 'txr_'
+
+    def __init__(self, display_name=None, inclusive=None, percentage=None,
+                 active=True, description=None, jurisdiction=None,
+                 metadata=None, **kwargs):
+        if kwargs:
+            raise UserError(400, 'Unexpected ' + ', '.join(kwargs.keys()))
+
+        inclusive = try_convert_to_bool(inclusive)
+        percentage = try_convert_to_float(percentage)
+        active = try_convert_to_bool(active)
+        try:
+            assert type(display_name) is str and display_name
+            assert type(inclusive) is bool
+            assert type(percentage) is float
+            assert type(active) is bool
+            assert percentage >= 0 and percentage <= 100
+            assert description is None or type(description) is str
+            assert jurisdiction is None or type(jurisdiction) is str
+        except AssertionError:
+            raise UserError(400, 'Bad request')
+
+        # All exceptions must be raised before this point.
+        super().__init__()
+
+        self.display_name = display_name
+        self.inclusive = inclusive
+        self.percentage = percentage
+        self.active = active
+        self.description = description
+        self.jurisdiction = jurisdiction
+        self.metadata = metadata or {}
+
+
 class Token(StripeObject):
     object = 'token'
     _id_prefix = 'tok_'

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -62,6 +62,14 @@ def random_id(n):
                    for i in range(n))
 
 
+def try_convert_to_bool(arg):
+    if arg == 'false':
+        return False
+    elif arg == 'true':
+        return True
+    return arg
+
+
 def try_convert_to_int(arg):
     if type(arg) == int:
         return arg
@@ -978,6 +986,7 @@ class InvoiceItem(StripeObject):
         amount = try_convert_to_int(amount)
         period_start = try_convert_to_int(period_start)
         period_end = try_convert_to_int(period_end)
+        proration = try_convert_to_bool(proration)
         try:
             if invoice is not None:
                 assert type(invoice) is str and invoice.startswith('in_')
@@ -1096,6 +1105,7 @@ class Plan(StripeObject):
         amount = try_convert_to_int(amount)
         interval_count = try_convert_to_int(interval_count)
         trial_period_days = try_convert_to_int(trial_period_days)
+        active = try_convert_to_bool(active)
         try:
             assert id is None or type(id) is str and id
             assert type(active) is bool
@@ -1173,6 +1183,7 @@ class Product(StripeObject):
         if kwargs:
             raise UserError(400, 'Unexpected ' + ', '.join(kwargs.keys()))
 
+        active = try_convert_to_bool(active)
         try:
             assert self._type(name) is str and name
             assert type in ('good', 'service')

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -27,7 +27,7 @@ from aiohttp import web
 from .resources import Charge, Coupon, Customer, \
                        Event, Invoice, InvoiceItem, Plan, \
                        Product, Refund, Source, Subscription, \
-                       SubscriptionItem, Token, extra_apis, store
+                       SubscriptionItem, TaxRate, Token, extra_apis, store
 from .errors import UserError
 from .webhooks import register_webhook
 
@@ -253,7 +253,7 @@ for method, url, func in extra_apis:
 
 for cls in (Charge, Coupon, Customer,
             Event, Invoice, InvoiceItem, Plan, Product,
-            Refund, Source, Subscription, SubscriptionItem, Token):
+            Refund, Source, Subscription, SubscriptionItem, TaxRate, Token):
     for method, url, func in (
             ('POST', '/v1/' + cls.object + 's', api_create),
             ('GET', '/v1/' + cls.object + 's/{id}', api_retrieve),

--- a/test.sh
+++ b/test.sh
@@ -27,6 +27,22 @@ cus=$(curl -sSf -u $SK: $HOST/v1/customers \
 curl -sSf -u $SK: $HOST/v1/customers/$cus/tax_ids \
      -d type=eu_vat -d value=DE123456789
 
+txr1=$(curl -sSf -u $SK: $HOST/v1/tax_rates \
+            -d display_name=VAT \
+            -d description='TVA France taux normal' \
+            -d jurisdiction=FR \
+            -d percentage=20.0 \
+            -d inclusive=false \
+      | grep -oE 'txr_\w+' | head -n 1)
+
+txr2=$(curl -sSf -u $SK: $HOST/v1/tax_rates \
+            -d display_name=VAT \
+            -d description='TVA France taux réduit' \
+            -d jurisdiction=FR \
+            -d percentage=10.0 \
+            -d inclusive=false \
+      | grep -oE 'txr_\w+' | head -n 1)
+
 curl -sSf -u $SK: $HOST/v1/plans \
    -d id=basique-mensuel \
    -d product[name]='Abonnement basique (mensuel)' \


### PR DESCRIPTION
#### fix: Accept booleans passed in x-www-form-urlencoded

Unlike JSON data, boolean values sent as
`application/x-www-form-urlencoded` are represented as strings. In this
example `active` has the value `"true"`:

    curl $HOST/v1/products -d name=T-shirt -d active=true

Let's decode `"false"` and `"true"` when needed.

---

#### feat(tax_rates): Implement TaxRate objects
