### PR TITLE
feat(tax_ids): Auto-verify tax IDs

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1613,7 +1613,16 @@ class TaxId(StripeObject):
         self.customer = customer
         self.type = type
         self.value = value
-        self.verification = {'status': 'pending'}
+
+        self.verification = {'status': 'verified',
+                             'verified_name': '',
+                             'verified_address': ''}
+        # Test values from
+        # https://stripe.com/docs/billing/testing#customer-tax-id-verfication
+        if '111111111' in value:
+            self.verification['status'] = 'unverified'
+        elif '222222222' in value:
+            self.verification['status'] = 'pending'
 
 
 class TaxRate(StripeObject):


### PR DESCRIPTION
Let's try to do the same as Stripe in test mode:
- by default, verify all tax IDs,
- detect custom values `000000000`, `111111111` and `222222222` like in
  https://stripe.com/docs/billing/testing#customer-tax-id-verfication
