### PR TITLE
fix(resources): Copy dict when exporting them

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -199,6 +199,8 @@ class StripeObject(object):
                 elif (isinstance(value, list) and len(value) and
                         isinstance(value[0], StripeObject)):
                     obj[key] = [item._export() for item in value]
+                elif isinstance(value, dict):
+                    obj[key] = value.copy()
                 else:
                     obj[key] = value
 


### PR DESCRIPTION
Otherwise, a request with `?expand[]=dict.property` will permanently
expand `property` in the object (it will no longer be a reference like
`"prop_W9gikYjrX0yGRb"`, but a dict like `{"id": "prop_W9gikYjrX0yGRb",
... }`.

Maybe it's needed to do a deep copy, but I'm not sure (all our Stripe
objects aren't very nested).