### PR TITLE
chore(CI): Temporarily disable Python nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ python:
   - 3.5
   - 3.6
   - 3.7
-  - nightly
+  # Python nightly currently disabled because of:
+  #     curl: (56) Recv failure: Connection reset by peer
+  # - nightly
 install:
   - pip install flake8 flake8-import-order doc8 Pygments
   - python setup.py sdist


### PR DESCRIPTION
Because tests currently fail with:

    $ ./test.sh
    +HOST=http://localhost:8420
    +SK=sk_test_12345
    +curl -sSf -u sk_test_12345: http://localhost:8420/v1/customers/ -d 'description=Adding a description...'
    curl: (56) Recv failure: Connection reset by peer
    The command "./test.sh" exited with 56.