### PR TITLE
Implement Payment Methods and Setup Intents

### DIFF
--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -25,7 +25,7 @@ import socket
 from aiohttp import web
 
 from .resources import Charge, Coupon, Customer, \
-                       Event, Invoice, InvoiceItem, Plan, \
+                       Event, Invoice, InvoiceItem, PaymentMethod, Plan, \
                        Product, Refund, Source, Subscription, \
                        SubscriptionItem, TaxRate, Token, extra_apis, store
 from .errors import UserError
@@ -252,7 +252,7 @@ for method, url, func in extra_apis:
 
 
 for cls in (Charge, Coupon, Customer,
-            Event, Invoice, InvoiceItem, Plan, Product,
+            Event, Invoice, InvoiceItem, PaymentMethod, Plan, Product,
             Refund, Source, Subscription, SubscriptionItem, TaxRate, Token):
     for method, url, func in (
             ('POST', '/v1/' + cls.object + 's', api_create),

--- a/test.sh
+++ b/test.sh
@@ -317,6 +317,11 @@ pm=$(curl -sSf -u $SK: $HOST/v1/payment_methods \
 curl -sSf -u $SK: $HOST/v1/payment_methods/$pm/attach \
      -d customer=$cus
 
+curl -sSf -u $SK: $HOST/v1/customers/$cus \
+     -d invoice_settings[default_payment_method]=$pm
+
+curl -sSf -u $SK: $HOST/v1/customers/$cus?expand%5B%5D=invoice_settings.default_payment_method
+
 curl -sSf -u $SK: $HOST/v1/payment_methods/$pm/detach -X POST
 
 pm=$(curl -sSf -u $SK: $HOST/v1/payment_methods \

--- a/test.sh
+++ b/test.sh
@@ -335,3 +335,27 @@ code=$(curl -s -o /dev/null -w "%{http_code}" -u $SK: \
             $HOST/v1/payment_methods/$pm/attach \
             -d customer=$cus)
 [ "$code" = 402 ]
+
+res=$(curl -sSf -u $SK: $HOST/v1/setup_intents -X POST)
+seti=$(echo "$res" | grep '"id"' | grep -oE 'seti_\w+' | head -n 1)
+seti_secret=$(echo $res | grep -oE 'seti_\w+_secret_\w+' | head -n 1)
+
+curl -sSf -u $SK: $HOST/v1/setup_intents/$seti/confirm -X POST
+
+curl -sSf -u $SK: $HOST/v1/setup_intents/$seti/cancel -X POST
+
+res=$(curl -sSf -u $SK: $HOST/v1/setup_intents -X POST)
+seti=$(echo "$res" | grep '"id"' | grep -oE 'seti_\w+' | head -n 1)
+seti_secret=$(echo $res | grep -oE 'seti_\w+_secret_\w+' | head -n 1)
+
+# This is what a Stripe.js request does:
+curl -sSf $HOST/v1/setup_intents/$seti/confirm \
+     -d key=pk_test_sldkjflaksdfj \
+     -d use_stripe_sdk=true \
+     -d client_secret=$seti_secret \
+     -d payment_method_data[type]=card \
+     -d payment_method_data[card][number]=4242424242424242 \
+     -d payment_method_data[card][cvc]=242 \
+     -d payment_method_data[card][exp_month]=4 \
+     -d payment_method_data[card][exp_year]=24 \
+     -d payment_method_data[billing_details][address][postal_code]=42424


### PR DESCRIPTION
#### feat(payment_methods): Implement PaymentMethod objects

---

#### feat(customers): Implement invoice_settings.default_payment_method

---

#### feat(setup_intents): Implement SetupIntent objects

And adapt localstripe.js to handle `next_action` (for SCA and 3D Secure
cards).
