### PR TITLE
Fix expand in POST, and in nested objects

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -219,13 +219,11 @@ class StripeObject(object):
                     do_expand(path, i)
             else:
                 k, path = path.split('.', 1) if '.' in path else (path, None)
-                if path is None:
-                    if obj[k] is not None:
-                        id = obj[k]
-                        assert type(id) is str
-                        cls = StripeObject._get_class_for_id(id)
-                        obj[k] = cls._api_retrieve(id)._export()
-                else:
+                if type(obj[k]) is str:
+                    id = obj[k]
+                    cls = StripeObject._get_class_for_id(id)
+                    obj[k] = cls._api_retrieve(id)._export()
+                if path is not None:
                     do_expand(path, obj[k])
         try:
             for path in expand:

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -198,7 +198,8 @@ def api_create(cls, url):
     async def f(request):
         data = await get_post_data(request)
         data = data or {}
-        return json_response(cls._api_create(**data)._export())
+        expand = data.pop('expand', None)
+        return json_response(cls._api_create(**data)._export(expand=expand))
     return f
 
 
@@ -217,7 +218,9 @@ def api_update(cls, url):
         data = await get_post_data(request)
         if not data:
             raise UserError(400, 'Bad request')
-        return json_response(cls._api_update(id, **data)._export())
+        expand = data.pop('expand', None)
+        return json_response(cls._api_update(id, **data)._export(
+            expand=expand))
     return f
 
 

--- a/test.sh
+++ b/test.sh
@@ -27,6 +27,8 @@ cus=$(curl -sSf -u $SK: $HOST/v1/customers \
 curl -sSf -u $SK: $HOST/v1/customers/$cus/tax_ids \
      -d type=eu_vat -d value=DE123456789
 
+curl -sSf -u $SK: $HOST/v1/customers/$cus?expand%5B%5D=tax_ids.data.customer
+
 txr1=$(curl -sSf -u $SK: $HOST/v1/tax_rates \
             -d display_name=VAT \
             -d description='TVA France taux normal' \


### PR DESCRIPTION
#### fix(expand): Accept expand in POST requests too

---

#### fix(expand): Handle expand in nested Stripe objects

For example:

    GET /v1/customers/cus_FVPpnJSC?expand[]=tax_ids.data.customer

or:

    POST /v1/subscriptions -d expand[]=latest_invoice.payment_intent
