### PR TITLE
feat(payment_intents): Implement PaymentIntent objects

### DIFF
--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -25,9 +25,10 @@ import socket
 from aiohttp import web
 
 from .resources import Charge, Coupon, Customer, \
-                       Event, Invoice, InvoiceItem, PaymentMethod, Plan, \
-                       Product, Refund, SetupIntent, Source, Subscription, \
-                       SubscriptionItem, TaxRate, Token, extra_apis, store
+                       Event, Invoice, InvoiceItem, PaymentIntent, \
+                       PaymentMethod, Plan, Product, Refund, SetupIntent, \
+                       Source, Subscription, SubscriptionItem, TaxRate, \
+                       Token, extra_apis, store
 from .errors import UserError
 from .webhooks import register_webhook
 
@@ -259,8 +260,8 @@ for method, url, func in extra_apis:
 
 
 for cls in (Charge, Coupon, Customer, Event, Invoice, InvoiceItem,
-            PaymentMethod, Plan, Product, Refund, SetupIntent, Source,
-            Subscription, SubscriptionItem, TaxRate, Token):
+            PaymentIntent, PaymentMethod, Plan, Product, Refund, SetupIntent,
+            Source, Subscription, SubscriptionItem, TaxRate, Token):
     for method, url, func in (
             ('POST', '/v1/' + cls.object + 's', api_create),
             ('GET', '/v1/' + cls.object + 's/{id}', api_retrieve),

--- a/test.sh
+++ b/test.sh
@@ -254,7 +254,8 @@ code=$(curl -s -o /dev/null -w "%{http_code}" -u $SK: \
 
 curl -sSf -u $SK: $HOST/v1/subscriptions \
      -d customer=$cus \
-     -d items[0][plan]=basique-mensuel
+     -d items[0][plan]=basique-mensuel \
+     -d expand[]=latest_invoice.payment_intent
 
 sub=$(curl -sSf -u $SK: $HOST/v1/subscriptions \
            -d customer=$cus \


### PR DESCRIPTION
See https://stripe.com/docs/payments/intents#intent-statuses.

Before:

    Subscription ↔ Invoice ↔ Charge

After:

    Subscription ↔ Invoice ↔ PaymentIntent ↔ Charge

Note: payment methods that `requires_action` (for instance 3D Secure)
are not yet implemented.