### PR TITLE
feat(payment_intents): Implement authentication step

### DIFF
--- a/localstripe/localstripe-v3.js
+++ b/localstripe/localstripe-v3.js
@@ -277,6 +277,36 @@ Stripe = (apiKey) => {
         }
       }
     },
+    handleCardPayment: async (clientSecret, element, data) => {
+      console.log('localstripe: Stripe().handleCardPayment()');
+      try {
+        const success = await openModal(
+          '3D Secure\nDo you want to confirm or cancel?',
+          'Complete authentication', 'Fail authentication');
+        const pi = clientSecret.match(/^(pi_\w+)_secret_/)[1];
+        const url = `${LOCALSTRIPE_SOURCE}/v1/payment_intents/${pi}` +
+                    `/_authenticate?success=${success}`;
+        const response = await fetch(url, {
+          method: 'POST',
+          body: JSON.stringify({
+            key: apiKey,
+            client_secret: clientSecret,
+          }),
+        });
+        const body = await response.json().catch(() => ({}));
+        if (response.status !== 200 || body.error) {
+          return {error: body.error};
+        } else {
+          return {paymentIntent: body};
+        }
+      } catch (err) {
+        if (typeof err === 'object' && err.error) {
+          return err;
+        } else {
+          return {error: err};
+        }
+      }
+    },
   };
 };
 

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -169,6 +169,7 @@ async def auth_middleware(request, handler):
             any(re.match(pattern, request.path) for pattern in (
                 r'^/v1/tokens$',
                 r'^/v1/sources$',
+                r'^/v1/payment_intents/\w+/_authenticate\b',
                 r'^/v1/setup_intents/\w+/confirm$',
                 r'^/v1/setup_intents/\w+/cancel$',
             )))


### PR DESCRIPTION
And adapt localstripe.js to handle `next_action` (for SCA and 3D Secure
cards).

---

Based on #73 and #74.