### PR TITLE
fix: Accept various types of boolean strings

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -68,10 +68,11 @@ def random_id(n):
 
 
 def try_convert_to_bool(arg):
-    if arg == 'false':
-        return False
-    elif arg == 'true':
-        return True
+    if type(arg) is str:
+        if arg.lower() == 'false':
+            return False
+        elif arg.lower() == 'true':
+            return True
     return arg
 
 


### PR DESCRIPTION
This follows commit 89116d9 "fix: Accept booleans passed in
x-www-form-urlencoded", by now accepting all types of booleans, even
`True` or `FALSE`.

It seems necessary when using the Stripe Python library with boolean
parameters (like `enable_incomplete_payments=False`).