### PR TITLE
bugfix: only parse charge source as a string if it is one

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -339,8 +339,7 @@ class Charge(StripeObject):
             source = customer_obj._get_default_payment_method_or_source()
             if source is None:
                 raise UserError(404, 'This customer has no payment method')
-
-        if source.startswith('pm_'):
+        elif source.startswith('pm_'):
             source = PaymentMethod._api_retrieve(source)
         elif source.startswith('src_'):
             source = Source._api_retrieve(source)

--- a/test.sh
+++ b/test.sh
@@ -246,6 +246,12 @@ ds=$(curl -sSf -u $SK: $HOST/v1/customers/$cus?expand%5B%5D=default_source \
      | grep -oE '"default_source": null",' || true)
 [ -z "$ds" ]
 
+# we can charge a customer without specifying the source
+curl -sSf -u $SK: $HOST/v1/charges \
+     -d customer=$cus \
+     -d amount=1000 \
+     -d currency=usd
+
 curl -sSf -u $SK: $HOST/v1/invoices?customer=$cus
 
 code=$(curl -s -o /dev/null -w "%{http_code}" -u $SK: \


### PR DESCRIPTION
Customer._get_default_payment_method_or_source() returns a Card/Source/PaymentMethod object, not a string, so when only a customer is provided, you get an error like:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/aiohttp/web_protocol.py", line 418, in start
    resp = await task
  File "/usr/local/lib/python3.7/site-packages/aiohttp/web_app.py", line 458, in _handle
    resp = await handler(request)
  File "/usr/local/lib/python3.7/site-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/root/localstripe/localstripe/server.py", line 56, in error_middleware
    return await handler(request)
  File "/root/localstripe/localstripe/server.py", line 192, in auth_middleware
    return await handler(request)
  File "/root/localstripe/localstripe/server.py", line 204, in f
    return json_response(cls._api_create(**data)._export(expand=expand))
  File "/root/localstripe/localstripe/resources.py", line 133, in _api_create
    return cls(**data)
  File "/root/localstripe/localstripe/resources.py", line 346, in __init__
    if source.startswith('pm_'):
AttributeError: 'Card' object has no attribute 'startswith'
```