### PR TITLE
Add alpine-based Dockerfile and move requirements to requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3-alpine
+RUN mkdir /app
+COPY localstripe /app/localstripe
+COPY requirements.txt /app/requirements.txt
+COPY LICENSE /app/LICENSE
+COPY README.rst /app/README.rst
+WORKDIR /app
+RUN pip install -r requirements.txt
+EXPOSE 8420
+CMD ["python", "-m", "localstripe"]

--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,12 @@ Docker image can be rebuilt using:
  CMD ["localstripe"]
  EOF
 
+Alternatively, you can clone this repository and run:
+
+.. code::
+
+ docker build --no-cache -t adrienverge/localstripe .
+
 Examples
 --------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+aiohttp >=2.3.2
+python-dateutil >=2.6.1

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+
 from setuptools import setup
 
 from localstripe import __author__, __version__
 
-with open('requirements.txt') as f:
+with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')) as f:
     requirements = f.read().splitlines()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ from setuptools import setup
 
 from localstripe import __author__, __version__
 
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
 
 setup(
     name='localstripe',
@@ -29,12 +31,9 @@ setup(
 
     packages=['localstripe'],
     entry_points={'console_scripts':
-                  ['localstripe=localstripe.server:start']},
+                      ['localstripe=localstripe.server:start']},
     package_data={
         'localstripe': ['localstripe-v3.js'],
     },
-    install_requires=[
-        'aiohttp >=2.3.2',
-        'python-dateutil >=2.6.1',
-    ],
+    install_requires=requirements
 )


### PR DESCRIPTION
Using the `python:3-alpine` image drops the final image size to 103MB, instead of the 946MB of the `python:3` based image. 