### PR TITLE
declined charge - 402 on create API

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -360,6 +360,8 @@ class Charge(StripeObject):
         # All exceptions must be raised before this point.
         super().__init__()
 
+        self._authorized = not source._charging_is_declined()
+
         self.amount = amount
         self.currency = currency
         self.customer = customer
@@ -378,8 +380,7 @@ class Charge(StripeObject):
     def _trigger_payment(self, on_success=None, on_failure_now=None,
                          on_failure_later=None):
         if self.payment_method.startswith('src_'):
-            source = Source._api_retrieve(self.payment_method)
-            if source._charging_is_declined():
+            if not self._authorized:
                 async def callback():
                     await asyncio.sleep(0.5)
                     self.status = 'failed'
@@ -395,10 +396,7 @@ class Charge(StripeObject):
 
         elif (self.payment_method.startswith('pm_') or
               self.payment_method.startswith('card_')):
-            pm = (Card._api_retrieve(self.payment_method)
-                  if self.payment_method.startswith('card_')
-                  else PaymentMethod._api_retrieve(self.payment_method))
-            if pm._charging_is_declined():
+            if not self._authorized:
                 self.status = 'failed'
                 self.failure_code = 'card_declined'
                 self.failure_message = 'Your card was declined.'
@@ -412,7 +410,9 @@ class Charge(StripeObject):
     @classmethod
     def _api_create(cls, **data):
         obj = super()._api_create(**data)
-        if obj.captured == False:
+
+        # for successful pre-auth, return unpaid charge
+        if not obj.captured and obj._authorized:
             return obj
 
         def on_failure():

--- a/test.sh
+++ b/test.sh
@@ -640,7 +640,7 @@ card=$(
        -d source[cvc]=123 \
   | grep -oE 'card_\w+' | head -n 1)
 
-# create a charge, observe 402 response
+# create a normal charge, observe 402 response
 code=$(
   curl -s -o /dev/null -w "%{http_code}" \
        -u $SK: $HOST/v1/charges \
@@ -649,12 +649,38 @@ code=$(
        -d currency=usd)
 [ "$code" = 402 ]
 
-# create a charge
+# create a normal charge
 charge=$(
   curl -s -u $SK: $HOST/v1/charges \
        -d source=$card \
        -d amount=1000 \
        -d currency=usd \
+  | grep -oE 'ch_\w+' | head -n 1)
+
+# verify charge status failed
+status=$(
+  curl -sSf -u $SK: $HOST/v1/charges/$charge \
+  | grep -oE '"status": "failed"')
+[ -n "$status" ]
+
+
+# create a pre-auth charge, observe 402 response
+code=$(
+  curl -s -o /dev/null -w "%{http_code}" \
+       -u $SK: $HOST/v1/charges \
+       -d source=$card \
+       -d amount=1000 \
+       -d currency=usd \
+       -d capture=false)
+[ "$code" = 402 ]
+
+# create a pre-auth charge
+charge=$(
+  curl -s -u $SK: $HOST/v1/charges \
+       -d source=$card \
+       -d amount=1000 \
+       -d currency=usd \
+       -d capture=false \
   | grep -oE 'ch_\w+' | head -n 1)
 
 # verify charge status failed

--- a/test.sh
+++ b/test.sh
@@ -585,3 +585,80 @@ fingerprint=$(
        -d card[cvc]=123 \
   | grep -oE '"fingerprint": "6589b0d46b6f2f0d",')
 [ -n "$fingerprint" ]
+
+# create a chargeable source
+card=$(
+  curl -sSf -u $SK: $HOST/v1/customers/$cus/cards \
+       -d source[object]=card \
+       -d source[number]=4242424242424242 \
+       -d source[exp_month]=12 \
+       -d source[exp_year]=2020 \
+       -d source[cvc]=123 \
+  | grep -oE 'card_\w+' | head -n 1)
+
+# create a normal charge, verify charge status succeeded
+status=$(
+  curl -sSf -u $SK: $HOST/v1/charges \
+       -d source=$card \
+       -d amount=1000 \
+       -d currency=usd \
+  | grep -oE '"status": "succeeded"')
+[ -n "$status" ]
+
+# create a pre-auth charge
+charge=$(
+  curl -sSf -u $SK: $HOST/v1/charges \
+       -d source=$card \
+       -d amount=1000 \
+       -d currency=usd \
+       -d capture=false \
+  | grep -oE 'ch_\w+' | head -n 1)
+
+# verify charge status pending
+status=$(
+  curl -sSf -u $SK: $HOST/v1/charges/$charge \
+  | grep -oE '"status": "pending"')
+[ -n "$status" ]
+
+# capture the charge
+curl -sSf -u $SK: $HOST/v1/charges/$charge/capture \
+     -X POST
+
+# verify charge status succeeded
+status=$(
+  curl -sSf -u $SK: $HOST/v1/charges/$charge \
+  | grep -oE '"status": "succeeded"')
+[ -n "$status" ]
+
+# create a non-chargeable source
+card=$(
+  curl -sSf -u $SK: $HOST/v1/customers/$cus/cards \
+       -d source[object]=card \
+       -d source[number]=4000000000000341 \
+       -d source[exp_month]=12 \
+       -d source[exp_year]=2020 \
+       -d source[cvc]=123 \
+  | grep -oE 'card_\w+' | head -n 1)
+
+# create a charge, observe 402 response
+code=$(
+  curl -s -o /dev/null -w "%{http_code}" \
+       -u $SK: $HOST/v1/charges \
+       -d source=$card \
+       -d amount=1000 \
+       -d currency=usd)
+[ "$code" = 402 ]
+
+# create a charge
+charge=$(
+  curl -s -u $SK: $HOST/v1/charges \
+       -d source=$card \
+       -d amount=1000 \
+       -d currency=usd \
+  | grep -oE 'ch_\w+' | head -n 1)
+
+# verify charge status failed
+status=$(
+  curl -sSf -u $SK: $HOST/v1/charges/$charge \
+  | grep -oE '"status": "failed"')
+[ -n "$status" ]


### PR DESCRIPTION
on real stripe, `POST /v1/charges` immediately processes the payment (or preauthorizes the funds for later when `capture=false`), and if this fails the response will be a 402 status code, with the [charge id](https://stripe.com/docs/api/errors#errors-charge) included in the response body.