### PR TITLE
Bulk compability enhancements with stripe api

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -736,6 +736,39 @@ class Customer(StripeObject):
         obj = cls._api_retrieve(id)
         return obj.tax_ids
 
+    @classmethod
+    def _api_add_subscription(cls, id, **data):
+        obj = Subscription(customer=id, **data)
+        return obj
+
+    @classmethod
+    def _api_retrieve_subscription(cls, id, subscription_id, **kwargs):
+        if kwargs:
+            raise UserError(400, 'Unexpected ' + ', '.join(kwargs.keys()))
+
+        obj = Subscription._api_retrieve(subscription_id)
+
+        if obj.customer != id:
+            raise UserError(400, 'Customer ' + id + ' does not have a subscription with ID ' + subscription_id)
+
+        return obj
+
+    @classmethod
+    def _api_update_subscription(cls, id, subscription_id, **data):
+        obj = Subscription._api_retrieve(subscription_id)
+
+        if obj.customer != id:
+            raise UserError(400, 'Customer ' + id + ' does not have a subscription with ID ' + subscription_id)
+
+        return obj._update(**data)
+
+    @classmethod
+    def _api_list_subscriptions(cls, id, **kwargs):
+        if kwargs:
+            raise UserError(400, 'Unexpected ' + ', '.join(kwargs.keys()))
+
+        return cls._api_retrieve(id).subscriptions
+
 
 extra_apis.extend((
     ('POST', '/v1/customers/{id}/sources', Customer._api_add_source),
@@ -748,6 +781,14 @@ extra_apis.extend((
     # Delete single source by id:
     ('DELETE', '/v1/customers/{id}/sources/{source_id}',
      Customer._api_remove_source),
+
+
+    # Subscription endpoints
+    ('GET', '/v1/customers/{id}/subscriptions', Customer._api_list_subscriptions),
+    ('POST', '/v1/customers/{id}/subscriptions', Customer._api_add_subscription),
+    ('GET', '/v1/customers/{id}/subscriptions/{subscription_id}', Customer._api_retrieve_subscription),
+    ('POST', '/v1/customers/{id}/subscriptions/{subscription_id}', Customer._api_update_subscription),
+
     # This is the old API route:
     ('POST', '/v1/customers/{id}/cards', Customer._api_add_source),
     ('POST', '/v1/customers/{id}/tax_ids', Customer._api_add_tax_id),

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1759,7 +1759,7 @@ class Product(StripeObject):
     object = 'product'
     _id_prefix = 'prod_'
 
-    def __init__(self, name=None, type=None, active=True, caption=None,
+    def __init__(self, id=None, name=None, type=None, active=True, caption=None,
                  description=None, attributes=None, shippable=True, url=None,
                  statement_descriptor=None, metadata=None, **kwargs):
         if kwargs:
@@ -1770,6 +1770,8 @@ class Product(StripeObject):
             assert _type(name) is str and name
             assert type in ('good', 'service')
             assert _type(active) is bool
+            if id is not None:
+                assert _type(id) is str
             if caption is not None:
                 assert _type(caption) is str
             if description is not None:
@@ -1786,7 +1788,7 @@ class Product(StripeObject):
             raise UserError(400, 'Bad request')
 
         # All exceptions must be raised before this point.
-        super().__init__()
+        super().__init__(id)
 
         self.name = name
         self.type = type

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2064,12 +2064,16 @@ class Subscription(StripeObject):
     _id_prefix = 'sub_'
 
     def __init__(self, customer=None, metadata=None, items=None,
+                 plan=None, quantity=None, # optional "items" dictionary
                  tax_percent=None,  # deprecated
                  enable_incomplete_payments=True,  # legacy support
                  payment_behavior='allow_incomplete',
                  trial_period_days=None, **kwargs):
         if kwargs:
             raise UserError(400, 'Unexpected ' + ', '.join(kwargs.keys()))
+
+        if items is None:
+            items = [{ 'plan': plan, 'quantity': quantity }]
 
         tax_percent = try_convert_to_float(tax_percent)
         enable_incomplete_payments = try_convert_to_bool(
@@ -2250,11 +2254,16 @@ class Subscription(StripeObject):
         self.status = 'past_due'
 
     def _update(self, metadata=None, items=None, tax_percent=None,
+                plan=None, quantity=None, # optional "items" dictionary
                 proration_date=None,
                 # Currently unimplemented, only False works as expected:
                 enable_incomplete_payments=False):
+        if items is None:
+            items = [{ 'plan': plan, 'quantity': quantity }]
+
         tax_percent = try_convert_to_float(tax_percent)
         proration_date = try_convert_to_int(proration_date)
+
         try:
             if tax_percent is not None:
                 assert type(tax_percent) is float

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2276,7 +2276,6 @@ class Subscription(StripeObject):
                 for item in items:
                     id = item.get('id', None)
                     plan = item.get('plan', None)
-                    assert id is not None or plan is not None
                     if id is not None:
                         assert type(id) is str and id.startswith('si_')
                     if item.get('quantity', None) is not None:
@@ -2295,8 +2294,12 @@ class Subscription(StripeObject):
         if tax_percent is not None:
             self.tax_percent = tax_percent
 
-        if items is None or len(items) != 1 or not items[0]['plan']:
+        if items is None or len(items) != 1:
             raise UserError(500, 'Not implemented')
+
+        # If no plan specified in update request, we stay on the current one
+        if not items[0]['plan']:
+            items[0]['plan'] = self.items._list[0].plan.id
 
         # To return 404 if not existant:
         new_plan = Plan._api_retrieve(items[0]['plan'])

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -251,6 +251,8 @@ def api_extra(func, url):
             data['id'] = request.match_info['id']
         if 'source_id' in request.match_info:
             data['source_id'] = request.match_info['source_id']
+        if 'subscription_id' in request.match_info:
+            data['subscription_id'] = request.match_info['subscription_id']
         return json_response(func(**data)._export())
     return f
 


### PR DESCRIPTION
This PR fixes #99 + further issues found while running our test suite to against Localstripe.

In highlights

- Adding endpoints for `/customers/:id/subscriptions[/:id]`
- Making the 'items' dictionary optional for `Subscription`. Using the Stripe PHP SDK it sets quantity and plan directly on the model - not in an 'items' dictionary
- Allow to update only 'quantity' on a subscription - without changing plans
- Add missing support for `trial_end`, `cancel_at_period_end`, `prorate`. All behavior may not be 100% in line with Stripe, but at least it does not throw exception