### PR TITLE
`default_tax_rate` for invoice and subscription

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1291,10 +1291,7 @@ class InvoiceItem(StripeObject):
     @property
     def tax_amounts(self):
         if self.tax_rates is not None:
-            return [{'amount': int(self.amount * tr.percentage / 100.0),
-                     'inclusive': tr.inclusive,
-                     'tax_rate': tr.id}
-                    for tr in self.tax_rates]
+            return [tr._tax_amount(self.amount) for tr in self.tax_rates]
 
     @classmethod
     def _api_list_all(cls, url, customer=None, limit=None):
@@ -2443,6 +2440,11 @@ class TaxRate(StripeObject):
         self.description = description
         self.jurisdiction = jurisdiction
         self.metadata = metadata or {}
+
+    def _tax_amount(self, amount):
+        return {'amount': int(amount * self.percentage / 100.0),
+                'inclusive': self.inclusive,
+                'tax_rate': self.id}
 
 
 class Token(StripeObject):


### PR DESCRIPTION
### refactor(invoice item): move `tax_amounts` inside `TaxRate` object

`tax_amounts` is the expression of a `TaxRate` on an amount, as describe here
for an invoice line item:
https://stripe.com/docs/api/invoices/line_item#invoice_line_item_object-tax_amounts

We will re-use it when applying an invoice `default_tax_rate` in a future
commit so let's move it inside the `TaxRate` object.

---
### feat(invoice): Implement `default_tax_rates` (v2)

From Stripe [`invoice creation API`], implement `default_tax_rates` parameter.
Subscriptions are not impacted yet (no `default_tax_rates` on subscription).

Revert part of the commit [`feat(invoices): Implement default_tax_rates`] that
wasn't saving `default_tax_rates` in the Invoice object and leads to various
issues.

[`invoice creation API`]: https://stripe.com/docs/api/invoices/create#create_invoice
[`feat(invoices): Implement default_tax_rates`]: https://github.com/adrienverge/localstripe/commit/af2335e

---
### feat(invoice): Implement `subscription_default_tax_rates`

From Stripe [`invoice upcoming API`], implement the simulation of an upcoming
invoice on a subscription that have default tax rates.

Revert part of the commit [`feat(invoices): Implement default_tax_rates`] that
was using an un-existing `default_tax_rates` parameters.

[`invoice upcoming API`]: https://stripe.com/docs/api/invoices/upcoming#upcoming_invoice-subscription_default_tax_rates
[`feat(invoices): Implement default_tax_rates`]: https://github.com/adrienverge/localstripe/commit/af2335e

---
### feat(subscription): Implement `default_tax_rates`

From Stripe [`subscriptions creation`] and [`subscriptions update`] API,
implement the `default_tax_rates` parameter.

When subscribing a customer to the subscription, invoices generated will use
the subscription `default_tax_rates` value, if not overwritten.

Revert part of the commit [`feat(invoices): Implement default_tax_rates`] that
was using `default_tax_rates` from invoice object, while it should use the one
of from subscription.

[`subscriptions creation`]: https://stripe.com/docs/api/subscriptions/create#create_subscription
[`subscriptions update`]: https://stripe.com/docs/api/subscriptions/update#update_subscription
[`feat(invoices): Implement default_tax_rates`]: https://github.com/adrienverge/localstripe/commit/af2335e
