### PR TITLE
feat(customer): Add subscription endpoints

### DIFF
--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -251,6 +251,8 @@ def api_extra(func, url):
             data['id'] = request.match_info['id']
         if 'source_id' in request.match_info:
             data['source_id'] = request.match_info['source_id']
+        if 'subscription_id' in request.match_info:
+            data['subscription_id'] = request.match_info['subscription_id']
         return json_response(func(**data)._export())
     return f
 

--- a/test.sh
+++ b/test.sh
@@ -429,6 +429,10 @@ curl -sSf -u $SK: $HOST/v1/subscriptions \
 
 curl -sSf -u $SK: $HOST/v1/invoices?customer=$cus
 
+curl -sSf -u $SK: $HOST/v1/subscriptions?customer=$cus
+
+curl -sSf -u $SK: $HOST/v1/customers/$cus/subscriptions
+
 cus=$(curl -sSf -u $SK: $HOST/v1/customers \
            -d description='This customer will have a subscription with graduated tiered pricing' \
            -d email=tiered@bar.com \


### PR DESCRIPTION
@rasmuscnielsen for info. This your commit (taken from https://github.com/adrienverge/localstripe/pull/101) with a few fixes:
```diff
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -738,8 +738,7 @@ class Customer(StripeObject):
 
     @classmethod
     def _api_add_subscription(cls, id, **data):
-        obj = Subscription(customer=id, **data)
-        return obj
+        return Subscription._api_create(customer=id, **data)
 
     @classmethod
     def _api_retrieve_subscription(cls, id, subscription_id, **kwargs):
@@ -749,7 +748,8 @@ class Customer(StripeObject):
         obj = Subscription._api_retrieve(subscription_id)
 
         if obj.customer != id:
-            raise UserError(400, 'Customer ' + id + ' does not have a subscription with ID ' + subscription_id)
+            raise UserError(404, 'Customer ' + id + ' does not have a '
+                                 'subscription with ID ' + subscription_id)
 
         return obj
 
@@ -758,9 +758,10 @@ class Customer(StripeObject):
         obj = Subscription._api_retrieve(subscription_id)
 
         if obj.customer != id:
-            raise UserError(400, 'Customer ' + id + ' does not have a subscription with ID ' + subscription_id)
+            raise UserError(404, 'Customer ' + id + ' does not have a '
+                                 'subscription with ID ' + subscription_id)
 
-        return obj._update(**data)
+        return Subscription._api_update(subscription_id, **data)
 
     @classmethod
     def _api_list_subscriptions(cls, id, **kwargs):
@@ -781,14 +782,14 @@ extra_apis.extend((
     # Delete single source by id:
     ('DELETE', '/v1/customers/{id}/sources/{source_id}',
      Customer._api_remove_source),
-
-
-    # Subscription endpoints
-    ('GET', '/v1/customers/{id}/subscriptions', Customer._api_list_subscriptions),
-    ('POST', '/v1/customers/{id}/subscriptions', Customer._api_add_subscription),
-    ('GET', '/v1/customers/{id}/subscriptions/{subscription_id}', Customer._api_retrieve_subscription),
-    ('POST', '/v1/customers/{id}/subscriptions/{subscription_id}', Customer._api_update_subscription),
-
+    ('GET', '/v1/customers/{id}/subscriptions',
+     Customer._api_list_subscriptions),
+    ('POST', '/v1/customers/{id}/subscriptions',
+     Customer._api_add_subscription),
+    ('GET', '/v1/customers/{id}/subscriptions/{subscription_id}',
+     Customer._api_retrieve_subscription),
+    ('POST', '/v1/customers/{id}/subscriptions/{subscription_id}',
+     Customer._api_update_subscription),
     # This is the old API route:
     ('POST', '/v1/customers/{id}/cards', Customer._api_add_source),
     ('POST', '/v1/customers/{id}/tax_ids', Customer._api_add_tax_id),
--- a/test.sh
+++ b/test.sh
@@ -429,6 +429,10 @@ curl -sSf -u $SK: $HOST/v1/subscriptions \
 
 curl -sSf -u $SK: $HOST/v1/invoices?customer=$cus
 
+curl -sSf -u $SK: $HOST/v1/subscriptions?customer=$cus
+
+curl -sSf -u $SK: $HOST/v1/customers/$cus/subscriptions
+
 cus=$(curl -sSf -u $SK: $HOST/v1/customers \
            -d description='This customer will have a subscription with graduated tiered pricing' \
            -d email=tiered@bar.com \
```