### PR TITLE
Allow updating a subscription without a plan id

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2344,7 +2344,6 @@ class Subscription(StripeObject):
                 assert type(items) is list
                 for item in items:
                     id = item.get('id', None)
-                    plan = item.get('plan', None)
                     if id is not None:
                         assert type(id) is str and id.startswith('si_')
                     if item.get('quantity', None) is not None:
@@ -2360,15 +2359,12 @@ class Subscription(StripeObject):
         except AssertionError:
             raise UserError(400, 'Bad request')
 
-        if tax_percent is not None:
-            self.tax_percent = tax_percent
-
         if items is None or len(items) != 1:
             raise UserError(500, 'Not implemented')
 
         # If no plan specified in update request, we stay on the current one
-        if not items[0]['plan']:
-            items[0]['plan'] = self.items._list[0].plan.id
+        if not items[0].get('plan', None):
+            items[0]['plan'] = self.plan.id
 
         # To return 404 if not existant:
         new_plan = Plan._api_retrieve(items[0]['plan'])

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2345,7 +2345,6 @@ class Subscription(StripeObject):
                 for item in items:
                     id = item.get('id', None)
                     plan = item.get('plan', None)
-                    assert id is not None or plan is not None
                     if id is not None:
                         assert type(id) is str and id.startswith('si_')
                     if item.get('quantity', None) is not None:
@@ -2361,8 +2360,15 @@ class Subscription(StripeObject):
         except AssertionError:
             raise UserError(400, 'Bad request')
 
-        if items is None or len(items) != 1 or not items[0]['plan']:
+        if tax_percent is not None:
+            self.tax_percent = tax_percent
+
+        if items is None or len(items) != 1:
             raise UserError(500, 'Not implemented')
+
+        # If no plan specified in update request, we stay on the current one
+        if not items[0]['plan']:
+            items[0]['plan'] = self.items._list[0].plan.id
 
         # To return 404 if not existant:
         new_plan = Plan._api_retrieve(items[0]['plan'])


### PR DESCRIPTION
When updating a subscription without sending a plan-id, it will simply stay on the same plan.
This is in accordance with the official stripe api.