### PR TITLE
Subscription update

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2379,8 +2379,7 @@ class Subscription(StripeObject):
             self.quantity = items[0]['quantity']
 
             if (self.items._list[0].plan.id != items[0]['plan'] or
-                    self.items._list[0].quantity != items[0]['quantity'] or
-                    self.items._list[0].tax_rates != items[0]['tax_rates']):
+                    self.items._list[0].quantity != items[0]['quantity']):
                 self.items = List('/v1/subscription_items?subscription=' +
                                   self.id)
                 item = SubscriptionItem(subscription=self.id,
@@ -2405,6 +2404,15 @@ class Subscription(StripeObject):
                                 description='Unused time',
                                 tax_rates=previous_tax_rates,
                                 customer=self.customer)
+
+            elif self.items._list[0].tax_rates != items[0]['tax_rates']:
+                self.items = List('/v1/subscription_items?subscription=' +
+                                  self.id)
+                item = SubscriptionItem(subscription=self.id,
+                                        plan=items[0]['plan'],
+                                        quantity=items[0]['quantity'],
+                                        tax_rates=items[0]['tax_rates'])
+                self.items._list.append(item)
 
         if tax_percent is not None:
             self.tax_percent = tax_percent

--- a/test.sh
+++ b/test.sh
@@ -455,6 +455,9 @@ same_data=$(curl -sSf -u $SK: $HOST/v1/subscriptions/$sub \
 
 diff <(echo "$data") <(echo "$same_data")
 
+curl -sSf -u $SK: $HOST/v1/subscriptions/$sub \
+     -d metadata[toto]=toto
+
 curl -sSf -u $SK: $HOST/v1/invoices?customer=$cus
 
 cus=$(curl -sSf -u $SK: $HOST/v1/customers \

--- a/test.sh
+++ b/test.sh
@@ -447,8 +447,13 @@ sub=$(curl -sSf -u $SK: $HOST/v1/subscriptions \
            -d items[0][quantity]=5 \
       | grep -oE 'sub_\w+' | head -n 1)
 
-curl -sSf -u $SK: $HOST/v1/subscriptions/$sub \
-     -d items[0][plan]=annual-tiered-volume
+data=$(curl -sSf -u $SK: $HOST/v1/subscriptions/$sub \
+            -d items[0][plan]=annual-tiered-volume)
+
+same_data=$(curl -sSf -u $SK: $HOST/v1/subscriptions/$sub \
+                 -d items[0][plan]=annual-tiered-volume)
+
+diff <(echo "$data") <(echo "$same_data")
 
 curl -sSf -u $SK: $HOST/v1/invoices?customer=$cus
 


### PR DESCRIPTION
### refactor(subscription): Split `_set_up_subscription_and_invoice()`

Function `_set_up_subscription_and_invoice()` of Subscription class, did:
- plan upgrade,
- subscription items update,
- previous invoice un-used time item creation (only on update)
- and, if needed, next invoice creation.

I think it is un-easy to modify to create new features.

I propose to break-it in smaller parts.

---
### fix(subscription): Make update idempotent

Before, calling `/subscription/id` two times with the same parameters was
re-creating part of the subscription:
- it'd recreate the subscription items and thus changed their ids
- it'd re-setup the plan and thus changed `current_period_start` and
  `current_period_end`

---
### feat(subscription): Make update work without the need of items

It allow to designate a subscription with his ID only, and update a small part
of it, like in this Stripe documentation extract:
```
curl https://api.stripe.com/v1/subscriptions/sub_GDjt2p38WYqAzx \
  -u sk_test_OuBu5ZGmCKUR1n0hUjPWIuey: \
  -d "metadata[order_id]"=6735
```

---
### fix(subscription): changing tax rate should not make unused time refund

Changing only the tax-rate of subscription items doesn't open to a refund of
unused time, as items themself are the same.

