### PR TITLE
Stripe JS handleCardSetup and handleCardPayment renaming

### DIFF
--- a/localstripe/localstripe-v3.js
+++ b/localstripe/localstripe-v3.js
@@ -215,21 +215,20 @@ Stripe = (apiKey) => {
     },
     retrieveSource: () => {}, // TODO
 
-    handleCardSetup: async (clientSecret, element, data) => {
-      console.log('localstripe: Stripe().handleCardSetup()');
+    confirmCardSetup: async (clientSecret, data) => {
+      console.log('localstripe: Stripe().confirmCardSetup()');
       try {
         const seti = clientSecret.match(/^(seti_\w+)_secret_/)[1];
         const url = `${LOCALSTRIPE_SOURCE}/v1/setup_intents/${seti}/confirm`;
-        if (element instanceof Element) {
-          data.payment_method_data =
-            data.payment_method_data || {};
-          data.payment_method_data.card = element.value.card;
-          data.payment_method_data.billing_details =
-            data.payment_method_data.billing_details || {};
-          data.payment_method_data.billing_details.address =
-            data.payment_method_data.billing_details.address || {};
-          data.payment_method_data.billing_details.address.postal_code =
-            data.payment_method_data.billing_details.address.postal_code ||
+        if (data.payment_method.card instanceof Element) {
+          const element = data.payment_method.card;
+          data.payment_method.card = element.value.card;
+          data.payment_method.billing_details =
+            data.payment_method.billing_details || {};
+          data.payment_method.billing_details.address =
+            data.payment_method.billing_details.address || {};
+          data.payment_method.billing_details.address.postal_code =
+            data.payment_method.billing_details.address.postal_code ||
             element.value.postal_code;
         }
         let response = await fetch(url, {
@@ -240,7 +239,7 @@ Stripe = (apiKey) => {
             client_secret: clientSecret,
             payment_method_data: {
               type: 'card',
-              ...data.payment_method_data,
+              ...data.payment_method,
             },
           }),
         });
@@ -284,6 +283,14 @@ Stripe = (apiKey) => {
         }
       }
     },
+    handleCardSetup:  // deprecated
+      async function (clientSecret, element, data) {
+        return this.confirmCardSetup(clientSecret, {
+          payment_method: {
+            card: element,
+            ...data.payment_method_data,
+          }});
+      },
     handleCardPayment: async (clientSecret, element, data) => {
       console.log('localstripe: Stripe().handleCardPayment()');
       try {

--- a/localstripe/localstripe-v3.js
+++ b/localstripe/localstripe-v3.js
@@ -291,8 +291,8 @@ Stripe = (apiKey) => {
             ...data.payment_method_data,
           }});
       },
-    handleCardPayment: async (clientSecret, element, data) => {
-      console.log('localstripe: Stripe().handleCardPayment()');
+    confirmCardPayment: async (clientSecret, data) => {
+      console.log('localstripe: Stripe().confirmCardPayment()');
       try {
         const success = await openModal(
           '3D Secure\nDo you want to confirm or cancel?',
@@ -321,6 +321,10 @@ Stripe = (apiKey) => {
         }
       }
     },
+    handleCardPayment:  // deprecated
+      async function (clientSecret, element, data) {
+        return this.confirmCardPayment(clientSecret);
+      },
 
     confirmSepaDebitSetup: async (clientSecret, data) => {
       console.log('localstripe: Stripe().confirmSepaDebitSetup()');


### PR DESCRIPTION
### feat(localstripe.js): Remove `address_zip` from `Element`

From a careful riding of the Stripe documentation, it seems that [`Element`]
does not have a `address_zip` field, but a `value.postal_code` field.
In the meantime, the function [`handleCardSetup()`] that consume it, seems
to look for postal code inside
`data.payment_method.billing_details.address.postal_code`, because, in the
background, it use the [`PaymentMethod`] API.

Let's use this structure, it will easy future compatibility with new
[`confirmCardSetup()`].

User be able to call the API like that which wasn't possible before:
```
Stripe().handleCardSetup(clientSecret, {
  {
    "number": "4242424242424242",
    "exp_month": 12,
    "exp_year": 2020,
    "cvc": "314",
  },
  payment_method_data: {
    billing_details: {
      address: {
        postal_code: '12345',
      },
    },
  },
});
```

[`Element`]: https://stripe.com/docs/js/element
[`handleCardSetup()`]: https://stripe.com/docs/js/deprecated/handle_card_payment_element
[`PaymentMethod`]: https://stripe.com/docs/api/payment_methods/object
[`confirmCardSetup()`]: https://stripe.com/docs/js/setup_intents/confirm_card_setup

---
### feat(localstripe.js): Rename `handleCardSetup` to `confirmCardSetup`

From Stripe documentation:
> handleCardSetup has been renamed to confirmCardSetup. In addition to the
> rename, we have slightly modified the arguments. These changes do not affect
> the behavior of the method. While we have no plans to ever remove support for
> handleCardSetup, we think the new name and arguments are easier to understand
> and better convey what the method is doing.

See:
https://stripe.com/docs/stripe-js/reference#stripe-handle-card-setup
https://stripe.com/docs/stripe-js/reference#stripe-confirm-card-setup

---
### feat(localstripe.js): Rename `handleCardPayment` → `confirmCardPayment`

From Stripe documentation:
> handleCardPayment has been renamed to confirmCardPayment. In addition to the
> rename, we have slightly modified the arguments. These changes do not affect
> the behavior of the method. While we have no plans to ever remove support for
> handleCardPayment, we think the new name and arguments are easier to
> understand and better convey what the method is doing.

See:
https://stripe.com/docs/stripe-js/reference#stripe-handle-card-payment
https://stripe.com/docs/stripe-js/reference#stripe-confirm-card-payment

