### PR TITLE
Support customer 'phone' and 'address'

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -565,9 +565,9 @@ class Customer(StripeObject):
         # All exceptions must be raised before this point.
         super().__init__()
 
-        self.name = name or ''
-        self.description = description or ''
-        self.email = email or ''
+        self.name = name
+        self.description = description
+        self.email = email
         self.invoice_settings = invoice_settings
         self.business_vat_id = business_vat_id
         self.preferred_locales = preferred_locales

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -524,7 +524,7 @@ class Customer(StripeObject):
     _id_prefix = 'cus_'
 
     def __init__(self, name=None, description=None, email=None,
-                 phone=None,
+                 phone=None, address=None,
                  invoice_settings=None, business_vat_id=None,
                  preferred_locales=None, tax_id_data=None,
                  metadata=None, **kwargs):
@@ -540,6 +540,12 @@ class Customer(StripeObject):
                 assert type(email) is str
             if phone is not None:
                 assert type(phone) is str
+            if address is not None:
+                assert type(address) is dict
+                assert set(address.keys()).issubset({
+                    'city', 'country', 'line1', 'line2', 'postal_code',
+                    'state'})
+                assert all(type(f) is str for f in address.values())
             if invoice_settings is None:
                 invoice_settings = {}
             assert type(invoice_settings) is dict
@@ -572,6 +578,7 @@ class Customer(StripeObject):
         self.description = description
         self.email = email
         self.phone = phone
+        self.address = address
         self.invoice_settings = invoice_settings
         self.business_vat_id = business_vat_id
         self.preferred_locales = preferred_locales

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -524,6 +524,7 @@ class Customer(StripeObject):
     _id_prefix = 'cus_'
 
     def __init__(self, name=None, description=None, email=None,
+                 phone=None,
                  invoice_settings=None, business_vat_id=None,
                  preferred_locales=None, tax_id_data=None,
                  metadata=None, **kwargs):
@@ -537,6 +538,8 @@ class Customer(StripeObject):
                 assert type(description) is str
             if email is not None:
                 assert type(email) is str
+            if phone is not None:
+                assert type(phone) is str
             if invoice_settings is None:
                 invoice_settings = {}
             assert type(invoice_settings) is dict
@@ -568,6 +571,7 @@ class Customer(StripeObject):
         self.name = name
         self.description = description
         self.email = email
+        self.phone = phone
         self.invoice_settings = invoice_settings
         self.business_vat_id = business_vat_id
         self.preferred_locales = preferred_locales

--- a/test.sh
+++ b/test.sh
@@ -21,6 +21,7 @@ curl -sSf -u $SK: -X DELETE $HOST/v1/customers/$cus
 cus=$(curl -sSf -u $SK: $HOST/v1/customers \
            -d description='This customer is a company' \
            -d email=foo@bar.com \
+           -d phone=0102030405 \
            -d tax_id_data[0][type]=eu_vat -d tax_id_data[0][value]=FR12345678901 \
       | grep -oE 'cus_\w+' | head -n 1)
 

--- a/test.sh
+++ b/test.sh
@@ -22,6 +22,8 @@ cus=$(curl -sSf -u $SK: $HOST/v1/customers \
            -d description='This customer is a company' \
            -d email=foo@bar.com \
            -d phone=0102030405 \
+           -d address[line1]='6 boulevard de Brandebourg' \
+           -d address[city]=Ivry-sur-Seine -d address[country]=FR \
            -d tax_id_data[0][type]=eu_vat -d tax_id_data[0][value]=FR12345678901 \
       | grep -oE 'cus_\w+' | head -n 1)
 


### PR DESCRIPTION
#### fix(customer): Allow name, description and email to be null

See officiel Stripe docs: these are `null` when unset.

---

#### feat(customer): Support phone field

---

#### feat(customer): Support address field

Fixes https://github.com/adrienverge/localstripe/issues/112.