### PR TITLE
Add start_date field when creating a subscription

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2258,6 +2258,7 @@ class Subscription(StripeObject):
         self.trial_start = None
         self.trial_period_days = trial_period_days
         self.latest_invoice = None
+        self.start_date = int(time.time())
         self._enable_incomplete_payments = (
             enable_incomplete_payments and
             payment_behavior != 'error_if_incomplete')

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2264,7 +2264,6 @@ class Subscription(StripeObject):
             payment_behavior != 'error_if_incomplete')
 
         self._set_up_plan(Plan._api_retrieve(items[0]['plan']))
-        self.start = self.current_period_start
 
         self.items = List('/v1/subscription_items?subscription=' + self.id)
         self.items._list.append(


### PR DESCRIPTION
As per issue #115 

This just defaults the start_date to the current time, which fixes our immediate use-case. I am regrettably not familiar enough with the Stripe APIs to know if it's correct in all cases.

I am not sure if anything needs to be added to test.sh - I find the file a bit hard to read.

I'm happy to discuss this issue further.