### PR TITLE
Add support invoice line items (il_) from Stripe API 2019-12-03

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1314,7 +1314,7 @@ extra_apis.extend((
 
 class InvoiceItem(StripeObject):
     object = 'invoiceitem'
-    _id_prefix = 'ii_'
+    _id_prefix = 'il_'
 
     def __init__(self, type='invoiceitem', invoice=None, subscription=None,
                  plan=None, amount=None, currency=None, customer=None,
@@ -1368,6 +1368,7 @@ class InvoiceItem(StripeObject):
         super().__init__()
 
         self.type = type
+        self.invoice_item = 'ii_' + self.id[3:]
         self.invoice = invoice
         self.subscription = subscription
         self.plan = plan


### PR DESCRIPTION
**feat(invoice item): Add support for type parameter**

Stripe API [2019-12-03] introduced a change for the InvoiceItems. We
now need to rely on the attibute `type` to identify InvoiceItems.

Let's support this!

[2019-12-03]: https://stripe.com/docs/upgrades#2019-12-03

---

**feat(invoice item): Add support for new ID format**

The InvoiceItem id format has changed in API version 2019-12-03.

Let's support this new format and add support for field `invoice_item`.