### PR TITLE
fix(expand): Accept max 4 levels of a property

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -195,6 +195,10 @@ class StripeObject(object):
         except AssertionError:
             raise UserError(400, 'Bad request')
 
+        if any(len(path.split('.')) > 4 for path in expand):
+            raise UserError(
+                400, 'You cannot expand more than 4 levels of a property')
+
         obj = {}
 
         # Take basic properties

--- a/test.sh
+++ b/test.sh
@@ -32,6 +32,12 @@ curl -sSf -u $SK: $HOST/v1/customers/$cus/tax_ids \
 
 curl -sSf -u $SK: $HOST/v1/customers/$cus?expand%5B%5D=tax_ids.data.customer
 
+curl -sSf -u $SK: $HOST/v1/customers/$cus?expand%5B%5D=subscriptions.data.items.data
+
+code=$(curl -so /dev/null -w '%{http_code}' -u $SK: \
+       $HOST/v1/customers/$cus?expand%5B%5D=subscriptions.data.items.data.tax_ids)
+[ "$code" -eq 400 ]
+
 txr1=$(curl -sSf -u $SK: $HOST/v1/tax_rates \
             -d display_name=VAT \
             -d description='TVA France taux normal' \


### PR DESCRIPTION
Like the real Stripe API does.