### PR TITLE
Fix incorrect invoice lines on subscription plan upgrade

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1126,20 +1126,17 @@ class Invoice(StripeObject):
         for si in items:
             if subscription_items is not None:
                 plan = Plan._api_retrieve(si['plan'])
-            else:
-                plan = si.plan
-            if subscription_items is not None:
+                quantity = si.get('quantity', 1)
                 tax_rates = si['tax_rates']
             else:
+                plan = si.plan
+                quantity = si.quantity
                 tax_rates = [tr.id for tr in (si.tax_rates or [])]
             invoice_items.append(
-                InvoiceItem(subscription=subscription,
-                            plan=plan.id,
-                            amount=plan.amount,
-                            currency=plan.currency,
-                            description=plan.name,
-                            tax_rates=tax_rates,
-                            customer=customer))
+                SubscriptionItem(subscription=subscription,
+                                 plan=plan.id,
+                                 quantity=quantity,
+                                 tax_rates=tax_rates))
 
         if tax_percent is None:
             if subscription_tax_percent is not None:
@@ -1441,9 +1438,7 @@ class InvoiceLineItem(StripeObject):
             self.currency = item.plan.currency
             self.description = item.plan.name
             self.amount = item._calculate_amount()
-            subscription_obj = Subscription._api_retrieve(item._subscription)
-            self.period = dict(start=subscription_obj.current_period_start,
-                               end=subscription_obj.current_period_end)
+            self.period = item._current_period()
         elif self.type == 'invoiceitem':
             self.invoice_item = item.id
             self.subscription = item.subscription
@@ -2366,8 +2361,6 @@ class Subscription(StripeObject):
             enable_incomplete_payments and
             payment_behavior != 'error_if_incomplete')
 
-        self._set_up_plan(Plan._api_retrieve(items[0]['plan']))
-
         self.items = List('/v1/subscription_items?subscription=' + self.id)
         self.items._list.append(
             SubscriptionItem(
@@ -2387,19 +2380,13 @@ class Subscription(StripeObject):
     def plan(self):
         return self.items._list[0].plan
 
-    def _set_up_plan(self, plan):
-        current_period_start = datetime.fromtimestamp(self.start_date)
-        current_period_end = current_period_start
-        if plan.interval == 'day':
-            current_period_end += timedelta(days=1)
-        elif plan.interval == 'week':
-            current_period_end += timedelta(days=7)
-        elif plan.interval == 'month':
-            current_period_end += relativedelta(months=1)
-        elif plan.interval == 'year':
-            current_period_end += relativedelta(years=1)
-        self.current_period_start = int(current_period_start.timestamp())
-        self.current_period_end = int(current_period_end.timestamp())
+    @property
+    def current_period_start(self):
+        return self.items._list[0]._current_period()['start']
+
+    @property
+    def current_period_end(self):
+        return self.items._list[0]._current_period()['end']
 
     def _create_invoice(self):
         pending_items = [ii for ii in InvoiceItem._api_list_all(
@@ -2600,10 +2587,6 @@ class Subscription(StripeObject):
         if cancel_at is not None:
             self.cancel_at = cancel_at
 
-        if (self.plan.interval != old_plan.interval or
-                self.plan.interval_count != old_plan.interval_count):
-            self._set_up_plan(Plan._api_retrieve(items[0]['plan']))
-
         # If the subscription is updated to a more expensive plan, an invoice
         # is not automatically generated. To achieve that, an invoice has to
         # be manually created using the POST /invoices route.
@@ -2656,8 +2639,9 @@ class SubscriptionItem(StripeObject):
 
         quantity = try_convert_to_int(quantity)
         try:
-            assert type(subscription) is str
-            assert subscription.startswith('sub_')
+            if subscription is not None:
+                assert type(subscription) is str
+                assert subscription.startswith('sub_')
             assert type(plan) is str
             assert type(quantity) is int and quantity > 0
             if tax_rates is not None:
@@ -2680,6 +2664,25 @@ class SubscriptionItem(StripeObject):
         self.metadata = metadata or {}
 
         self._subscription = subscription
+
+    def _current_period(self):
+        if self._subscription:
+            obj = Subscription._api_retrieve(self._subscription).start_date
+            start_date = obj
+        else:
+            start_date = int(time.time())
+
+        end_date = datetime.fromtimestamp(start_date)
+        if self.plan.interval == 'day':
+            end_date += timedelta(days=1)
+        elif self.plan.interval == 'week':
+            end_date += timedelta(days=7)
+        elif self.plan.interval == 'month':
+            end_date += relativedelta(months=1)
+        elif self.plan.interval == 'year':
+            end_date += relativedelta(years=1)
+
+        return dict(start=start_date, end=int(end_date.timestamp()))
 
     def _calculate_amount(self):
         if self.plan.billing_scheme == 'per_unit':

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1172,15 +1172,18 @@ class Invoice(StripeObject):
                                              subscription=subscription,
                                              limit=99)
                 for previous_invoice in previous._list:
-                    previous_tax_rates = \
-                        [tr.id
-                         for tr in previous_invoice.lines._list[0].tax_rates]
+                    old_plan = previous_invoice.lines._list[0].plan
+                    old_tax_rates = [
+                        tr.id
+                        for tr in previous_invoice.lines._list[0].tax_rates]
                     invoice_items.append(
                         InvoiceItem(amount=- previous_invoice.subtotal,
                                     currency=previous_invoice.currency,
                                     proration=True,
                                     description='Unused time',
-                                    tax_rates=previous_tax_rates,
+                                    subscription=subscription,
+                                    plan=old_plan.id,
+                                    tax_rates=old_tax_rates,
                                     customer=customer,
                                     period_start=previous_invoice.period_start,
                                     period_end=previous_invoice.period_end))
@@ -1443,8 +1446,8 @@ class InvoiceLineItem(StripeObject):
                                end=subscription_obj.current_period_end)
         elif self.type == 'invoiceitem':
             self.invoice_item = item.id
-            self.subscription = None
-            self.plan = None
+            self.subscription = item.subscription
+            self.plan = item.plan
             self.proration = item.proration
             self.currency = item.currency
             self.description = item.description
@@ -2568,6 +2571,8 @@ class Subscription(StripeObject):
                                 currency=previous_invoice.currency,
                                 proration=True,
                                 description='Unused time',
+                                subscription=self.id,
+                                plan=old_plan.id,
                                 tax_rates=previous_tax_rates,
                                 customer=self.customer)
 

--- a/test.sh
+++ b/test.sh
@@ -470,6 +470,30 @@ curl -sSf -u $SK: $HOST/v1/subscriptions/$sub \
 curl -sSf -u $SK: $HOST/v1/invoices?customer=$cus
 
 cus=$(curl -sSf -u $SK: $HOST/v1/customers \
+           -d description='This customer will switch from a yearly to another
+                           yearly plan' \
+           -d email=switch@bar.com \
+      | grep -oE 'cus_\w+' | head -n 1)
+
+curl -sSf -u $SK: $HOST/v1/customers/$cus/sources \
+     -d source=$tok
+
+sub=$(curl -sSf -u $SK: $HOST/v1/subscriptions \
+           -d customer=$cus \
+           -d items[0][plan]=basique-annuel)
+sub_id=$(echo "$sub" | grep -oE 'sub_\w+' | head -n 1)
+sub_item_id=$(echo "$sub" | grep -oE 'si_\w+' | head -n 1)
+
+sub=$(curl -sSf -u $SK: $HOST/v1/subscriptions/$sub_id \
+           -d items[0][plan]=pro-annuel \
+           -d items[0][id]=$sub_item_id)
+
+in=$(curl -sSf -u $SK: $HOST/v1/invoices \
+          -d customer=$cus)
+grep -q "Abonnement PRO (annuel)" <<<"$in"
+grep -q "Abonnement basique (annuel)" <<<"$in"
+
+cus=$(curl -sSf -u $SK: $HOST/v1/customers \
            -d email=john.malkovich@example.com \
       | grep -oE 'cus_\w+' | head -n 1)
 


### PR DESCRIPTION
### InvoiceItem: Include 'plan' and 'subscription' info if available

That's what real Stripe does, e.g. on a plan upgrade:

```yaml
[
  {
    "id": "il_1GbU4aKxWWXl12QBOzUyETIM",
    "type": "invoiceitem",
    "subscription_item": "si_H9nhRadSKnHfBu",
    "invoice_item": "ii_1GbU4bKxWWXl12QBhGX2ce3u",
    "amount": -1000,
    "description": "Unused time on Plan after 24 Apr 2020",
    "plan": { "id": "monthly-plan", ... },
    "proration": true
  },
  {
    "id": "il_1GbU4bKxWWXl12QCMJnxK6Ws",
    "type": "subscription",
    "subscription_item": "si_H9nhRadSKnHfBu",
    "amount": 9900,
    "currency": "eur",
    "description": "1 × Plan (at €99.00 / year)",
    "plan": { "id": "yearly-plan", ... },
    "proration": false
  }
]
```

---

### Invoice: Create SubscriptionItems (not InvoiceItems) for upcoming

This fixes a bug when a subscription is upgraded to another plan with a
different billing cycle (e.g. monthly to yearly). In such a case, the
invoice is generated when the user creates the invoice then calls API
`/pay`, but in this case the invoice is made from
`Invoice._get_next_invoice()`, not from `Subscription._create_invoice()`.

Subsciption items need to be created as `SubscriptionItem`, not
`InvoiceItem` (since commit a80dda2 "feat: Support invoice line items
(il_) from Stripe API 2019-12-03").