### PR TITLE
Subscription: Correctly set latest_invoice on manual payment

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -841,7 +841,7 @@ class Invoice(StripeObject):
 
     def __init__(self, customer=None, subscription=None, metadata=None,
                  items=[], date=None, description=None,
-                 simulation=False,
+                 simulation=False, upcoming=False,
                  tax_percent=None,  # deprecated
                  default_tax_rates=None,
                  **kwargs):
@@ -935,7 +935,10 @@ class Invoice(StripeObject):
         self._draft = True
         self._voided = False
 
-        if not simulation:
+        if not simulation and not upcoming:
+            if subscription is not None:
+                subscription_obj.latest_invoice = self.id
+
             schedule_webhook(Event('invoice.created', self))
 
     @property
@@ -1155,7 +1158,8 @@ class Invoice(StripeObject):
             raise UserError(404, 'No upcoming invoices for customer')
 
         elif not simulation and current_subscription:
-            return cls(customer=customer,
+            return cls(upcoming=upcoming,
+                       customer=customer,
                        subscription=current_subscription.id,
                        items=invoice_items,
                        tax_percent=tax_percent,
@@ -2415,7 +2419,6 @@ class Subscription(StripeObject):
             default_tax_rates=[tr.id
                                for tr in (self.default_tax_rates or [])],
             date=self.current_period_start)
-        self.latest_invoice = invoice.id
         invoice._finalize()
         if invoice.status != 'paid':  # 0 € invoices are already 'paid'
             Invoice._api_pay_invoice(invoice.id)


### PR DESCRIPTION
This fixes the following bug: if a subscription was upgraded to a plan
with the same billing cycle (e.g. yearly → yearly), and the user
generated the invoice manually, then the `Subscription.latest_invoice`
wasn't updated to the new value.