### PR TITLE
refactor: Rename a variable to fix lint rule E741

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -564,7 +564,7 @@ class Customer(StripeObject):
                 assert type(business_vat_id) is str
             if preferred_locales is not None:
                 assert type(preferred_locales) is list
-                assert all(type(l) is str for l in preferred_locales)
+                assert all(type(lo) is str for lo in preferred_locales)
             if tax_id_data is None:
                 tax_id_data = []
             assert type(tax_id_data) is list


### PR DESCRIPTION
Log of the CI before this commit:
```
$ if [[ $TRAVIS_PYTHON_VERSION != nightly ]]; then flake8 .; fi
./localstripe/resources.py:594:47: E741 ambiguous variable name 'l'
The command "if [[ $TRAVIS_PYTHON_VERSION != nightly ]]; then flake8 .; fi"
exited with 1.
```