### PR TITLE
convert: add double convert to int on error

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -518,7 +518,7 @@ class Coupon(StripeObject):
             raise UserError(400, 'Unexpected ' + ', '.join(kwargs.keys()))
 
         amount_off = try_convert_to_int(amount_off)
-        percent_off = try_convert_to_int(percent_off)
+        percent_off = try_convert_to_float(percent_off)
         duration_in_months = try_convert_to_int(duration_in_months)
         try:
             assert type(id) is str and id


### PR DESCRIPTION
This allows converting values like `"50.0"` which is what stripe-go will post for the `percent_off` value in POST coupon.

Sorry I'm not much of a python guy, so I'm not sure if the double try is very idiomatic. I'd be happy to change it if you have a better suggestion.

Thanks