### PR TITLE
fix(resources): Check that coupon `percent_off` is float not int

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -526,7 +526,7 @@ class Coupon(StripeObject):
             if amount_off is not None:
                 assert type(amount_off) is int and amount_off >= 0
             if percent_off is not None:
-                assert type(percent_off) is int
+                assert type(percent_off) is float
                 assert percent_off >= 0 and percent_off <= 100
             assert duration in ('forever', 'once', 'repeating')
             if amount_off is not None:


### PR DESCRIPTION
Since commit 4810d4b _coupon: use float value for percent_off_ the following
unit test is failing:
```
...
+ curl -sSf -u sk_test_12345: http://localhost:8420/v1/coupons -d id=PARRAIN
  -d percent_off=30 -d duration=once
curl: (22) The requested URL returned error: 400 Bad Request
```

It's because, in the code just after 4810d4b change, the expected type for
`percent_off` is still `int`.