### PR TITLE
Support Python 3.8 and 3.9 and fix Travis problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 ---
 language: python
-dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 python:
-  - 3.5
-  - 3.6
   - 3.7
-  # Python nightly currently disabled because of:
-  #     curl: (56) Recv failure: Connection reset by peer
+  - 3.8
+  - 3.9-dev
+  # Python nightly currently disabled because of compilation issues
   # - nightly
 install:
   - pip install flake8 flake8-import-order doc8 Pygments

--- a/test.sh
+++ b/test.sh
@@ -6,19 +6,19 @@ set -eux
 HOST=http://localhost:8420
 SK=sk_test_12345
 
-cus=$(curl -sSf -u $SK: $HOST/v1/customers \
+cus=$(curl -sSfg -u $SK: $HOST/v1/customers \
           -d email=james.robinson@example.com \
       | grep -oE 'cus_\w+' | head -n 1)
 
-curl -sSf -u $SK: $HOST/v1/customers/$cus \
+curl -sSfg -u $SK: $HOST/v1/customers/$cus \
      -d description='Adding a description...'
 
-curl -sSf -u $SK: $HOST/v1/customers/$cus \
+curl -sSfg -u $SK: $HOST/v1/customers/$cus \
      -d preferred_locales[]='fr-FR' -d preferred_locales[]='es-ES'
 
-curl -sSf -u $SK: -X DELETE $HOST/v1/customers/$cus
+curl -sSfg -u $SK: -X DELETE $HOST/v1/customers/$cus
 
-cus=$(curl -sSf -u $SK: $HOST/v1/customers \
+cus=$(curl -sSfg -u $SK: $HOST/v1/customers \
            -d description='This customer is a company' \
            -d email=foo@bar.com \
            -d phone=0102030405 \
@@ -27,19 +27,19 @@ cus=$(curl -sSf -u $SK: $HOST/v1/customers \
            -d tax_id_data[0][type]=eu_vat -d tax_id_data[0][value]=FR12345678901 \
       | grep -oE 'cus_\w+' | head -n 1)
 
-curl -sSf -u $SK: $HOST/v1/customers/$cus/tax_ids \
+curl -sSfg -u $SK: $HOST/v1/customers/$cus/tax_ids \
      -d type=eu_vat -d value=DE123456789 \
      -d expand[]=customer
 
-curl -sSf -u $SK: $HOST/v1/customers/$cus?expand%5B%5D=tax_ids.data.customer
+curl -sSfg -u $SK: $HOST/v1/customers/$cus?expand[]=tax_ids.data.customer
 
-curl -sSf -u $SK: $HOST/v1/customers/$cus?expand%5B%5D=subscriptions.data.items.data
+curl -sSfg -u $SK: $HOST/v1/customers/$cus?expand[]=subscriptions.data.items.data
 
-code=$(curl -so /dev/null -w '%{http_code}' -u $SK: \
-       $HOST/v1/customers/$cus?expand%5B%5D=subscriptions.data.items.data.tax_ids)
+code=$(curl -sg -o /dev/null -w '%{http_code}' -u $SK: \
+       $HOST/v1/customers/$cus?expand[]=subscriptions.data.items.data.tax_ids)
 [ "$code" -eq 400 ]
 
-txr1=$(curl -sSf -u $SK: $HOST/v1/tax_rates \
+txr1=$(curl -sSfg -u $SK: $HOST/v1/tax_rates \
             -d display_name=VAT \
             -d description='TVA France taux normal' \
             -d jurisdiction=FR \
@@ -47,7 +47,7 @@ txr1=$(curl -sSf -u $SK: $HOST/v1/tax_rates \
             -d inclusive=false \
       | grep -oE 'txr_\w+' | head -n 1)
 
-txr2=$(curl -sSf -u $SK: $HOST/v1/tax_rates \
+txr2=$(curl -sSfg -u $SK: $HOST/v1/tax_rates \
             -d display_name=VAT \
             -d description='TVA France taux réduit' \
             -d jurisdiction=FR \
@@ -55,21 +55,21 @@ txr2=$(curl -sSf -u $SK: $HOST/v1/tax_rates \
             -d inclusive=false \
       | grep -oE 'txr_\w+' | head -n 1)
 
-curl -sSf -u $SK: $HOST/v1/plans \
+curl -sSfg -u $SK: $HOST/v1/plans \
    -d id=basique-mensuel \
    -d product[name]='Abonnement basique (mensuel)' \
    -d amount=2500 \
    -d currency=eur \
    -d interval=month
 
-curl -sSf -u $SK: $HOST/v1/plans \
+curl -sSfg -u $SK: $HOST/v1/plans \
    -d id=basique-annuel \
    -d name='Abonnement basique (annuel)' \
    -d amount=20000 \
    -d currency=eur \
    -d interval=year
 
-curl -sSf -u $SK: $HOST/v1/plans \
+curl -sSfg -u $SK: $HOST/v1/plans \
    -d id=annual-tiered-volume \
    -d name='Annual tiered volume' \
    -d currency=eur \
@@ -85,7 +85,7 @@ curl -sSf -u $SK: $HOST/v1/plans \
    -d tiers[1][unit_amount]=1000 \
    -d tiers[1][flat_amount]=1200
 
-curl -sSf -u $SK: $HOST/v1/plans \
+curl -sSfg -u $SK: $HOST/v1/plans \
    -d id=monthly-tiered-graduated \
    -d name='Monthly tiered graduated' \
    -d currency=eur \
@@ -101,7 +101,7 @@ curl -sSf -u $SK: $HOST/v1/plans \
    -d tiers[1][unit_amount]=1000 \
    -d tiers[1][flat_amount]=1200
 
-curl -sSf -u $SK: $HOST/v1/plans \
+curl -sSfg -u $SK: $HOST/v1/plans \
    -d id=pro-annuel \
    -d product[name]='Abonnement PRO (annuel)' \
    -d product[statement_descriptor]='abonnement pro' \
@@ -109,57 +109,57 @@ curl -sSf -u $SK: $HOST/v1/plans \
    -d currency=eur \
    -d interval=year
 
-curl -sSf -u $SK: $HOST/v1/plans \
+curl -sSfg -u $SK: $HOST/v1/plans \
    -d product[name]='Without id' \
    -d product[statement_descriptor]='Without id' \
    -d amount=30000 \
    -d currency=eur \
    -d interval=year
 
-curl -sSf -u $SK: $HOST/v1/plans \
+curl -sSfg -u $SK: $HOST/v1/plans \
    -d id=delete-me \
    -d product[name]='Delete me' \
    -d amount=30000 \
    -d currency=eur \
    -d interval=year
 
-curl -sSf -u $SK: -X DELETE $HOST/v1/plans/delete-me
+curl -sSfg -u $SK: -X DELETE $HOST/v1/plans/delete-me
 
-code=$(curl -so /dev/null -w '%{http_code}' -u $SK: $HOST/v1/plans \
+code=$(curl -sg -o /dev/null -w '%{http_code}' -u $SK: $HOST/v1/plans \
             -d doesnotexist=1)
 [ "$code" -eq 400 ]
 
-code=$(curl -so /dev/null -w '%{http_code}' -u $SK: \
+code=$(curl -sg -o /dev/null -w '%{http_code}' -u $SK: \
             $HOST/v1/plans?doesnotexist=1)
 [ "$code" -eq 400 ]
 
-curl -sSf -u $SK: $HOST/v1/products \
+curl -sSfg -u $SK: $HOST/v1/products \
      -d name=T-shirt \
      -d type=good \
      -d description='Comfortable cotton t-shirt' \
      -d attributes[]=size \
      -d attributes[]=gender
 
-curl -sSf -u $SK: $HOST/v1/products \
+curl -sSfg -u $SK: $HOST/v1/products \
      -d id=PRODUCT1234 \
      -d name='Product 1234' \
      -d type=service
 
-curl -sSf -u $SK: $HOST/v1/products/PRODUCT1234
+curl -sSfg -u $SK: $HOST/v1/products/PRODUCT1234
 
-curl -sSf -u $SK: $HOST/v1/plans?expand%5B%5D=data.product
+curl -sSfg -u $SK: $HOST/v1/plans?expand[]=data.product
 
-code=$(curl -so /dev/null -w '%{http_code}' -u $SK: \
-            $HOST/v1/plans?expand%5B%5D=data.doesnotexist)
+code=$(curl -sg -o /dev/null -w '%{http_code}' -u $SK: \
+            $HOST/v1/plans?expand[]=data.doesnotexist)
 [ "$code" -eq 400 ]
 
-curl -sSf -u $SK: $HOST/v1/coupons \
+curl -sSfg -u $SK: $HOST/v1/coupons \
    -d id=PARRAIN \
    -d percent_off=30 \
    -d duration=once
 
 # This is what a Stripe.js request does:
-tok=$(curl -sSf $HOST/v1/tokens \
+tok=$(curl -sSfg $HOST/v1/tokens \
           -d key=pk_test_sldkjflaksdfj \
           -d card[number]=4242424242424242 \
           -d card[exp_month]=12 \
@@ -167,23 +167,23 @@ tok=$(curl -sSf $HOST/v1/tokens \
           -d card[cvc]=123 \
       | grep -oE 'tok_\w+')
 
-curl -sSf -u $SK: $HOST/v1/customers/$cus/sources \
+curl -sSfg -u $SK: $HOST/v1/customers/$cus/sources \
      -d source=$tok
 
 # This is what a request from back-end does:
-tok=$(curl -sSf -u $SK: $HOST/v1/tokens \
+tok=$(curl -sSfg -u $SK: $HOST/v1/tokens \
            -d card[number]=4242424242424242 \
            -d card[exp_month]=12 \
            -d card[exp_year]=2019 \
            -d card[cvc]=123 \
       | grep -oE 'tok_\w+')
 
-curl -sSf -u $SK: $HOST/v1/customers/$cus/sources \
+curl -sSfg -u $SK: $HOST/v1/customers/$cus/sources \
      -d source=$tok
 
 # add a new card
 card=$(
-  curl -sSf -u $SK: $HOST/v1/customers/$cus/cards \
+  curl -sSfg -u $SK: $HOST/v1/customers/$cus/cards \
        -d source[object]=card \
        -d source[number]=4242424242424242 \
        -d source[exp_month]=12 \
@@ -193,23 +193,23 @@ card=$(
 
 # observe new card in customer response
 res=$(
-  curl -sSf -u $SK: $HOST/v1/customers/$cus \
+  curl -sSfg -u $SK: $HOST/v1/customers/$cus \
   | grep -oE $card)
 [ -n "$res" ]
 
 # delete the card
-curl -sSf -u $SK: $HOST/v1/customers/$cus/sources/$card \
+curl -sSfg -u $SK: $HOST/v1/customers/$cus/sources/$card \
      -X DELETE
 
 # observe card no longer in customer response
 res=$(
-  curl -sSf -u $SK: $HOST/v1/customers/$cus \
+  curl -sSfg -u $SK: $HOST/v1/customers/$cus \
   | grep -oE $card || true)
 [ -z "$res" ]
 
 # add a new card
 card=$(
-  curl -sSf -u $SK: $HOST/v1/customers/$cus/cards \
+  curl -sSfg -u $SK: $HOST/v1/customers/$cus/cards \
        -d source[object]=card \
        -d source[number]=4242424242424242 \
        -d source[exp_month]=12 \
@@ -220,21 +220,21 @@ card=$(
 
 # observe name on card
 name=$(
-  curl -sSf -u $SK: $HOST/v1/customers/$cus/sources/$card \
+  curl -sSfg -u $SK: $HOST/v1/customers/$cus/sources/$card \
   | grep -oE '"name": "John Smith",')
 [ -n "$name" ]
 
 # update name on card
-curl -sSf -u $SK: $HOST/v1/customers/$cus/sources/$card \
+curl -sSfg -u $SK: $HOST/v1/customers/$cus/sources/$card \
      -d name=Jane\ Doe
 
 # observe name on card
 name=$(
-  curl -sSf -u $SK: $HOST/v1/customers/$cus/sources/$card \
+  curl -sSfg -u $SK: $HOST/v1/customers/$cus/sources/$card \
   | grep -oE '"name": "Jane Doe",')
 [ -n "$name" ]
 
-card=$(curl -sSf -u $SK: $HOST/v1/customers/$cus/cards \
+card=$(curl -sSfg -u $SK: $HOST/v1/customers/$cus/cards \
           -d source[object]=card \
           -d source[number]=4242424242424242 \
           -d source[exp_month]=12 \
@@ -242,7 +242,7 @@ card=$(curl -sSf -u $SK: $HOST/v1/customers/$cus/cards \
           -d source[cvc]=123 \
       | grep -oE 'card_\w+')
 
-code=$(curl -s -o /dev/null -w "%{http_code}" -u $SK: \
+code=$(curl -sg -o /dev/null -w "%{http_code}" -u $SK: \
             $HOST/v1/customers/$cus/cards \
             -d source[object]=card \
             -d source[number]=4000000000000002 \
@@ -253,7 +253,7 @@ code=$(curl -s -o /dev/null -w "%{http_code}" -u $SK: \
 
 # new charges are captured by default
 captured=$(
-  curl -sSf -u $SK: $HOST/v1/charges \
+  curl -sSfg -u $SK: $HOST/v1/charges \
        -d customer=$cus \
        -d source=$card \
        -d amount=1000 \
@@ -263,7 +263,7 @@ captured=$(
 
 # create a pre-auth charge
 charge=$(
-  curl -sSf -u $SK: $HOST/v1/charges \
+  curl -sSfg -u $SK: $HOST/v1/charges \
        -d customer=$cus \
        -d source=$card \
        -d amount=1000 \
@@ -273,33 +273,33 @@ charge=$(
 
 # charge was not captured
 captured=$(
-  curl -sSf -u $SK: $HOST/v1/charges/$charge \
+  curl -sSfg -u $SK: $HOST/v1/charges/$charge \
   | grep -oE '"captured": false,')
 [ -n "$captured" ]
 
 # cannot capture more than pre-authed amount
 code=$(
-  curl -s -o /dev/null -w "%{http_code}" \
+  curl -sg -o /dev/null -w "%{http_code}" \
        -u $SK: $HOST/v1/charges/$charge/capture \
        -d amount=2000)
 [ "$code" = 400 ]
 
 # can capture less than the pre-auth amount
 captured=$(
-  curl -sSf -u $SK: $HOST/v1/charges/$charge/capture \
+  curl -sSfg -u $SK: $HOST/v1/charges/$charge/capture \
        -d amount=800 \
   | grep -oE '"captured": true,')
 [ -n "$captured" ]
 
 # difference between pre-auth and capture is refunded
 refunded=$(
-  curl -sSf -u $SK: $HOST/v1/charges/$charge \
+  curl -sSfg -u $SK: $HOST/v1/charges/$charge \
   | grep -oE '"amount_refunded": 200,')
 [ -n "$captured" ]
 
 # create a pre-auth charge
 charge=$(
-  curl -sSf -u $SK: $HOST/v1/charges \
+  curl -sSfg -u $SK: $HOST/v1/charges \
        -d customer=$cus \
        -d source=$card \
        -d amount=1000 \
@@ -309,195 +309,195 @@ charge=$(
 
 # capture the full amount (default)
 captured=$(
-  curl -sSf -u $SK: $HOST/v1/charges/$charge/capture \
+  curl -sSfg -u $SK: $HOST/v1/charges/$charge/capture \
        -X POST \
   | grep -oE '"captured": true,')
 [ -n "$captured" ]
 
 # none is refunded
 refunded=$(
-  curl -sSf -u $SK: $HOST/v1/charges/$charge \
+  curl -sSfg -u $SK: $HOST/v1/charges/$charge \
   | grep -oE '"amount_refunded": 0,')
 [ -n "$captured" ]
 
 # cannot capture an already captured charge
 code=$(
-  curl -s -o /dev/null -w "%{http_code}" \
+  curl -sg -o /dev/null -w "%{http_code}" \
        -u $SK: $HOST/v1/charges/$charge/capture \
        -X POST)
 [ "$code" = 400 ]
 
 sepa_cus=$(
-  curl -sSf -u $SK: $HOST/v1/customers \
+  curl -sSfg -u $SK: $HOST/v1/customers \
        -d description='I pay with SEPA debit' \
        -d email=sepa@euro.fr \
   | grep -oE 'cus_\w+' | head -n 1)
 
-src=$(curl -sSf -u $SK: $HOST/v1/sources \
+src=$(curl -sSfg -u $SK: $HOST/v1/sources \
            -d type=ach_credit_transfer \
            -d currency=usd \
            -d owner[email]='jenny.rosen@example.com' \
       | grep -oE 'src_\w+')
 
-curl -sSf -u $SK: $HOST/v1/customers/$sepa_cus/sources \
+curl -sSfg -u $SK: $HOST/v1/customers/$sepa_cus/sources \
      -d source=$src
 
 # This is what a Stripe.js request does:
-src=$(curl -sSf -u $SK: $HOST/v1/sources \
+src=$(curl -sSfg -u $SK: $HOST/v1/sources \
            -d type=sepa_debit \
            -d sepa_debit[iban]=DE89370400440532013000 \
            -d currency=eur \
            -d owner[name]='Jenny Rosen' \
       | grep -oE 'src_\w+')
 
-curl -sSf -u $SK: $HOST/v1/customers/$sepa_cus/sources \
+curl -sSfg -u $SK: $HOST/v1/customers/$sepa_cus/sources \
      -d source=$src
 
 # Get a customer source directly:
-curl -sSf -u $SK: $HOST/v1/customers/$sepa_cus/sources/$src
-code=$(curl -s -o /dev/null -w "%{http_code}" -u $SK: \
+curl -sSfg -u $SK: $HOST/v1/customers/$sepa_cus/sources/$src
+code=$(curl -sg -o /dev/null -w "%{http_code}" -u $SK: \
             $HOST/v1/customers/cus_doesnotexist/sources/$src)
 [ "$code" = 404 ]
-code=$(curl -s -o /dev/null -w "%{http_code}" -u $SK: \
+code=$(curl -sg -o /dev/null -w "%{http_code}" -u $SK: \
             $HOST/v1/customers/$sepa_cus/sources/src_doesnotexist)
 [ "$code" = 404 ]
 
-tok=$(curl -sSf -u $SK: $HOST/v1/tokens \
+tok=$(curl -sSfg -u $SK: $HOST/v1/tokens \
            -d card[number]=4242424242424242 \
            -d card[exp_month]=12 \
            -d card[exp_year]=2020 \
            -d card[cvc]=123 \
       | grep -oE 'tok_\w+')
 
-curl -sSf -u $SK: $HOST/v1/customers \
+curl -sSfg -u $SK: $HOST/v1/customers \
      -d description='Customer with already existing source' \
      -d source=$tok
 
 # For a customer with no source, `default_source` should be `null`:
-cus=$(curl -sSf -u $SK: $HOST/v1/customers -d email=joe.malvic@example.com \
+cus=$(curl -sSfg -u $SK: $HOST/v1/customers -d email=joe.malvic@example.com \
       | grep -oE 'cus_\w+' | head -n 1)
-ds=$(curl -sSf -u $SK: $HOST/v1/customers/$cus?expand%5B%5D=default_source \
+ds=$(curl -sSfg -u $SK: $HOST/v1/customers/$cus?expand[]=default_source \
      | grep -oE '"default_source": \w+,')
 [ "$ds" = '"default_source": null,' ]
-curl -sSf -u $SK: $HOST/v1/customers/$cus/cards \
+curl -sSfg -u $SK: $HOST/v1/customers/$cus/cards \
           -d source[object]=card \
           -d source[number]=4242424242424242 \
           -d source[exp_month]=12 \
           -d source[exp_year]=2020 \
           -d source[cvc]=123
-ds=$(curl -sSf -u $SK: $HOST/v1/customers/$cus?expand%5B%5D=default_source \
+ds=$(curl -sSfg -u $SK: $HOST/v1/customers/$cus?expand[]=default_source \
      | grep -oE '"default_source": null",' || true)
 [ -z "$ds" ]
 
 # we can charge a customer without specifying the source
-curl -sSf -u $SK: $HOST/v1/charges \
+curl -sSfg -u $SK: $HOST/v1/charges \
      -d customer=$cus \
      -d amount=1000 \
      -d currency=usd
 
-curl -sSf -u $SK: $HOST/v1/invoices?customer=$cus
+curl -sSfg -u $SK: $HOST/v1/invoices?customer=$cus
 
-code=$(curl -s -o /dev/null -w "%{http_code}" -u $SK: \
+code=$(curl -sg -o /dev/null -w "%{http_code}" -u $SK: \
             $HOST/v1/invoices/upcoming?customer=$cus)
 [ "$code" = 404 ]
 
-curl -sSf -u $SK: $HOST/v1/subscriptions \
+curl -sSfg -u $SK: $HOST/v1/subscriptions \
      -d customer=$cus \
      -d items[0][plan]=basique-mensuel \
      -d expand[]=latest_invoice.payment_intent
 
-res=$(curl -sSf -u $SK: $HOST/v1/subscriptions \
+res=$(curl -sSfg -u $SK: $HOST/v1/subscriptions \
            -d customer=$cus \
            -d items[0][plan]=basique-mensuel \
            -d items[0][tax_rates][0]=$txr1)
 sub=$(echo "$res" | grep -oE 'sub_\w+' | head -n 1)
 in=$(echo "$res" | grep -oE 'in_\w+' | head -n 1)
 
-curl -sSf -u $SK: $HOST/v1/invoices?customer=$cus
+curl -sSfg -u $SK: $HOST/v1/invoices?customer=$cus
 
-curl -sSf -u $SK: $HOST/v1/invoices/upcoming?customer=$cus
+curl -sSfg -u $SK: $HOST/v1/invoices/upcoming?customer=$cus
 
-curl -sSf -u $SK: $HOST/v1/invoices/upcoming?customer=$cus\&subscription_items%5B0%5D%5Bplan%5D=pro-annuel\&subscription_tax_percent=20
+curl -sSfg -u $SK: $HOST/v1/invoices/upcoming?customer=$cus\&subscription_items[0][plan]=pro-annuel\&subscription_tax_percent=20
 
-curl -sSf -u $SK: $HOST/v1/invoices/upcoming?customer=$cus\&subscription=$sub\&subscription_items%5B0%5D%5Bid%5D=si_RBrVStcKDimMnp\&subscription_items%5B0%5D%5Bplan%5D=basique-annuel\&subscription_proration_date=1504182686\&subscription_tax_percent=20
+curl -sSfg -u $SK: $HOST/v1/invoices/upcoming?customer=$cus\&subscription=$sub\&subscription_items[0][id]=si_RBrVStcKDimMnp\&subscription_items[0][plan]=basique-annuel\&subscription_proration_date=1504182686\&subscription_tax_percent=20
 
-curl -sSf -u $SK: $HOST/v1/invoices/$in/lines
+curl -sSfg -u $SK: $HOST/v1/invoices/$in/lines
 
-cus=$(curl -sSf -u $SK: $HOST/v1/customers \
+cus=$(curl -sSfg -u $SK: $HOST/v1/customers \
            -d description='This customer will have a subscription with volume tiered pricing' \
            -d email=tiered@bar.com \
       | grep -oE 'cus_\w+' | head -n 1)
 
-curl -sSf -u $SK: $HOST/v1/customers/$cus/sources \
+curl -sSfg -u $SK: $HOST/v1/customers/$cus/sources \
      -d source=$tok
 
-curl -sSf -u $SK: $HOST/v1/subscriptions \
+curl -sSfg -u $SK: $HOST/v1/subscriptions \
       -d customer=$cus \
       -d items[0][plan]=annual-tiered-volume \
       -d items[0][quantity]=5
 
-curl -sSf -u $SK: $HOST/v1/invoices?customer=$cus
+curl -sSfg -u $SK: $HOST/v1/invoices?customer=$cus
 
-curl -sSf -u $SK: $HOST/v1/subscriptions?customer=$cus
+curl -sSfg -u $SK: $HOST/v1/subscriptions?customer=$cus
 
-curl -sSf -u $SK: $HOST/v1/customers/$cus/subscriptions
+curl -sSfg -u $SK: $HOST/v1/customers/$cus/subscriptions
 
-cus=$(curl -sSf -u $SK: $HOST/v1/customers \
+cus=$(curl -sSfg -u $SK: $HOST/v1/customers \
            -d description='This customer will have a subscription with graduated tiered pricing' \
            -d email=tiered@bar.com \
       | grep -oE 'cus_\w+' | head -n 1)
 
-curl -sSf -u $SK: $HOST/v1/customers/$cus/sources \
+curl -sSfg -u $SK: $HOST/v1/customers/$cus/sources \
      -d source=$tok
 
-sub=$(curl -sSf -u $SK: $HOST/v1/subscriptions \
+sub=$(curl -sSfg -u $SK: $HOST/v1/subscriptions \
            -d customer=$cus \
            -d items[0][plan]=monthly-tiered-graduated \
            -d items[0][quantity]=5 \
       | grep -oE 'sub_\w+' | head -n 1)
 
-data=$(curl -sSf -u $SK: $HOST/v1/subscriptions/$sub \
+data=$(curl -sSfg -u $SK: $HOST/v1/subscriptions/$sub \
             -d items[0][plan]=annual-tiered-volume)
 
-same_data=$(curl -sSf -u $SK: $HOST/v1/subscriptions/$sub \
+same_data=$(curl -sSfg -u $SK: $HOST/v1/subscriptions/$sub \
                  -d items[0][plan]=annual-tiered-volume)
 
 diff <(echo "$data") <(echo "$same_data")
 
-curl -sSf -u $SK: $HOST/v1/subscriptions/$sub \
+curl -sSfg -u $SK: $HOST/v1/subscriptions/$sub \
      -d metadata[toto]=toto
 
-curl -sSf -u $SK: $HOST/v1/invoices?customer=$cus
+curl -sSfg -u $SK: $HOST/v1/invoices?customer=$cus
 
-cus=$(curl -sSf -u $SK: $HOST/v1/customers \
+cus=$(curl -sSfg -u $SK: $HOST/v1/customers \
            -d description='This customer will switch from a yearly to another
                            yearly plan' \
            -d email=switch@bar.com \
       | grep -oE 'cus_\w+' | head -n 1)
 
-curl -sSf -u $SK: $HOST/v1/customers/$cus/sources \
+curl -sSfg -u $SK: $HOST/v1/customers/$cus/sources \
      -d source=$tok
 
-sub=$(curl -sSf -u $SK: $HOST/v1/subscriptions \
+sub=$(curl -sSfg -u $SK: $HOST/v1/subscriptions \
            -d customer=$cus \
            -d items[0][plan]=basique-annuel)
 sub_id=$(echo "$sub" | grep -oE 'sub_\w+' | head -n 1)
 sub_item_id=$(echo "$sub" | grep -oE 'si_\w+' | head -n 1)
 
-sub=$(curl -sSf -u $SK: $HOST/v1/subscriptions/$sub_id \
+sub=$(curl -sSfg -u $SK: $HOST/v1/subscriptions/$sub_id \
            -d items[0][plan]=pro-annuel \
            -d items[0][id]=$sub_item_id)
 
-in=$(curl -sSf -u $SK: $HOST/v1/invoices \
+in=$(curl -sSfg -u $SK: $HOST/v1/invoices \
           -d customer=$cus)
 grep -q "Abonnement PRO (annuel)" <<<"$in"
 grep -q "Abonnement basique (annuel)" <<<"$in"
 
-cus=$(curl -sSf -u $SK: $HOST/v1/customers \
+cus=$(curl -sSfg -u $SK: $HOST/v1/customers \
            -d email=john.malkovich@example.com \
       | grep -oE 'cus_\w+' | head -n 1)
 
-pm=$(curl -sSf -u $SK: $HOST/v1/payment_methods \
+pm=$(curl -sSfg -u $SK: $HOST/v1/payment_methods \
           -d type=card \
           -d card[number]=4242424242424242 \
           -d card[exp_month]=12 \
@@ -505,46 +505,46 @@ pm=$(curl -sSf -u $SK: $HOST/v1/payment_methods \
           -d card[cvc]=123 \
      | grep -oE 'pm_\w+' | head -n 1)
 
-curl -sSf -u $SK: $HOST/v1/payment_methods/$pm/attach \
+curl -sSfg -u $SK: $HOST/v1/payment_methods/$pm/attach \
      -d customer=$cus
 
-curl -sSf -u $SK: $HOST/v1/customers/$cus \
+curl -sSfg -u $SK: $HOST/v1/customers/$cus \
      -d invoice_settings[default_payment_method]=$pm
 
-curl -sSf -u $SK: $HOST/v1/customers/$cus?expand%5B%5D=invoice_settings.default_payment_method
+curl -sSfg -u $SK: $HOST/v1/customers/$cus?expand[]=invoice_settings.default_payment_method
 
-curl -sSf -u $SK: $HOST/v1/payment_methods?customer=$cus\&type=card
+curl -sSfg -u $SK: $HOST/v1/payment_methods?customer=$cus\&type=card
 
-curl -sSf -u $SK: $HOST/v1/payment_methods/$pm/detach -X POST
+curl -sSfg -u $SK: $HOST/v1/payment_methods/$pm/detach -X POST
 
-pm=$(curl -sSf -u $SK: $HOST/v1/payment_methods \
+pm=$(curl -sSfg -u $SK: $HOST/v1/payment_methods \
           -d type=card \
           -d card[number]=4000000000000002 \
           -d card[exp_month]=4 \
           -d card[exp_year]=2042 \
           -d card[cvc]=123 \
      | grep -oE 'pm_\w+' | head -n 1)
-code=$(curl -s -o /dev/null -w "%{http_code}" -u $SK: \
+code=$(curl -sg -o /dev/null -w "%{http_code}" -u $SK: \
             $HOST/v1/payment_methods/$pm/attach \
             -d customer=$cus)
 [ "$code" = 402 ]
 
-curl -sSf -u $SK: $HOST/v1/payment_methods?customer=$cus\&type=card
+curl -sSfg -u $SK: $HOST/v1/payment_methods?customer=$cus\&type=card
 
-res=$(curl -sSf -u $SK: $HOST/v1/setup_intents -X POST)
+res=$(curl -sSfg -u $SK: $HOST/v1/setup_intents -X POST)
 seti=$(echo "$res" | grep '"id"' | grep -oE 'seti_\w+' | head -n 1)
 seti_secret=$(echo $res | grep -oE 'seti_\w+_secret_\w+' | head -n 1)
 
-curl -sSf -u $SK: $HOST/v1/setup_intents/$seti/confirm -X POST
+curl -sSfg -u $SK: $HOST/v1/setup_intents/$seti/confirm -X POST
 
-curl -sSf -u $SK: $HOST/v1/setup_intents/$seti/cancel -X POST
+curl -sSfg -u $SK: $HOST/v1/setup_intents/$seti/cancel -X POST
 
-res=$(curl -sSf -u $SK: $HOST/v1/setup_intents -X POST)
+res=$(curl -sSfg -u $SK: $HOST/v1/setup_intents -X POST)
 seti=$(echo "$res" | grep '"id"' | grep -oE 'seti_\w+' | head -n 1)
 seti_secret=$(echo $res | grep -oE 'seti_\w+_secret_\w+' | head -n 1)
 
 # This is what a Stripe.js request does:
-curl -sSf $HOST/v1/setup_intents/$seti/confirm \
+curl -sSfg $HOST/v1/setup_intents/$seti/confirm \
      -d key=pk_test_sldkjflaksdfj \
      -d use_stripe_sdk=true \
      -d client_secret=$seti_secret \
@@ -557,7 +557,7 @@ curl -sSf $HOST/v1/setup_intents/$seti/confirm \
 
 # off_session cannot be used when confirm is false
 code=$(
-  curl -s -o /dev/null -w "%{http_code}" \
+  curl -sg -o /dev/null -w "%{http_code}" \
        -u $SK: $HOST/v1/payment_intents \
        -d amount=1000 \
        -d currency=usd \
@@ -567,7 +567,7 @@ code=$(
 
 # card fingerprint
 fingerprint=$(
-  curl -sSf -u $SK: $HOST/v1/customers/$cus/cards \
+  curl -sSfg -u $SK: $HOST/v1/customers/$cus/cards \
        -d source[object]=card \
        -d source[number]=4242424242424242 \
        -d source[exp_month]=12 \
@@ -577,7 +577,7 @@ fingerprint=$(
 [ -n "$fingerprint" ]
 
 fingerprint=$(
-  curl -sSf -u $SK: $HOST/v1/customers/$cus/cards \
+  curl -sSfg -u $SK: $HOST/v1/customers/$cus/cards \
        -d source[object]=card \
        -d source[number]=4000056655665556 \
        -d source[exp_month]=12 \
@@ -587,7 +587,7 @@ fingerprint=$(
 [ -n "$fingerprint" ]
 
 fingerprint=$(
-  curl -sSf -u $SK: $HOST/v1/customers/$cus/cards \
+  curl -sSfg -u $SK: $HOST/v1/customers/$cus/cards \
        -d source[object]=card \
        -d source[number]=5555555555554444 \
        -d source[exp_month]=12 \
@@ -598,7 +598,7 @@ fingerprint=$(
 
 # sepa debit fingerprint
 fingerprint=$(
-  curl -sSf -u $SK: $HOST/v1/sources \
+  curl -sSfg -u $SK: $HOST/v1/sources \
        -d type=sepa_debit \
        -d sepa_debit[iban]=DE89370400440532013000 \
        -d currency=eur \
@@ -606,7 +606,7 @@ fingerprint=$(
 [ -n "$fingerprint" ]
 
 fingerprint=$(
-  curl -sSf -u $SK: $HOST/v1/sources \
+  curl -sSfg -u $SK: $HOST/v1/sources \
        -d type=sepa_debit \
        -d sepa_debit[iban]=FR1420041010050500013M02606 \
        -d currency=eur \
@@ -614,7 +614,7 @@ fingerprint=$(
 [ -n "$fingerprint" ]
 
 fingerprint=$(
-  curl -sSf -u $SK: $HOST/v1/sources \
+  curl -sSfg -u $SK: $HOST/v1/sources \
        -d type=sepa_debit \
        -d sepa_debit[iban]=IT40S0542811101000000123456 \
        -d currency=eur \
@@ -623,7 +623,7 @@ fingerprint=$(
 
 # payment method fingerprint
 fingerprint=$(
-  curl -sSf -u $SK: $HOST/v1/payment_methods \
+  curl -sSfg -u $SK: $HOST/v1/payment_methods \
        -d type=card \
        -d card[number]=4242424242424242 \
        -d card[exp_month]=12 \
@@ -633,7 +633,7 @@ fingerprint=$(
 [ -n "$fingerprint" ]
 
 fingerprint=$(
-  curl -sSf -u $SK: $HOST/v1/payment_methods \
+  curl -sSfg -u $SK: $HOST/v1/payment_methods \
        -d type=card \
        -d card[number]=4000056655665556 \
        -d card[exp_month]=12 \
@@ -643,7 +643,7 @@ fingerprint=$(
 [ -n "$fingerprint" ]
 
 fingerprint=$(
-  curl -sSf -u $SK: $HOST/v1/payment_methods \
+  curl -sSfg -u $SK: $HOST/v1/payment_methods \
        -d type=card \
        -d card[number]=5555555555554444 \
        -d card[exp_month]=12 \
@@ -654,7 +654,7 @@ fingerprint=$(
 
 # create a chargeable source
 card=$(
-  curl -sSf -u $SK: $HOST/v1/customers/$cus/cards \
+  curl -sSfg -u $SK: $HOST/v1/customers/$cus/cards \
        -d source[object]=card \
        -d source[number]=4242424242424242 \
        -d source[exp_month]=12 \
@@ -664,7 +664,7 @@ card=$(
 
 # create a normal charge, verify charge status succeeded
 status=$(
-  curl -sSf -u $SK: $HOST/v1/charges \
+  curl -sSfg -u $SK: $HOST/v1/charges \
        -d source=$card \
        -d amount=1000 \
        -d currency=usd \
@@ -673,7 +673,7 @@ status=$(
 
 # create a pre-auth charge
 charge=$(
-  curl -sSf -u $SK: $HOST/v1/charges \
+  curl -sSfg -u $SK: $HOST/v1/charges \
        -d source=$card \
        -d amount=1000 \
        -d currency=usd \
@@ -682,23 +682,23 @@ charge=$(
 
 # verify charge status pending
 status=$(
-  curl -sSf -u $SK: $HOST/v1/charges/$charge \
+  curl -sSfg -u $SK: $HOST/v1/charges/$charge \
   | grep -oE '"status": "pending"')
 [ -n "$status" ]
 
 # capture the charge
-curl -sSf -u $SK: $HOST/v1/charges/$charge/capture \
+curl -sSfg -u $SK: $HOST/v1/charges/$charge/capture \
      -X POST
 
 # verify charge status succeeded
 status=$(
-  curl -sSf -u $SK: $HOST/v1/charges/$charge \
+  curl -sSfg -u $SK: $HOST/v1/charges/$charge \
   | grep -oE '"status": "succeeded"')
 [ -n "$status" ]
 
 # create a non-chargeable source
 card=$(
-  curl -sSf -u $SK: $HOST/v1/customers/$cus/cards \
+  curl -sSfg -u $SK: $HOST/v1/customers/$cus/cards \
        -d source[object]=card \
        -d source[number]=4000000000000341 \
        -d source[exp_month]=12 \
@@ -708,7 +708,7 @@ card=$(
 
 # create a normal charge, observe 402 response
 code=$(
-  curl -s -o /dev/null -w "%{http_code}" \
+  curl -sg -o /dev/null -w "%{http_code}" \
        -u $SK: $HOST/v1/charges \
        -d source=$card \
        -d amount=1000 \
@@ -717,7 +717,7 @@ code=$(
 
 # create a normal charge
 charge=$(
-  curl -s -u $SK: $HOST/v1/charges \
+  curl -sg -u $SK: $HOST/v1/charges \
        -d source=$card \
        -d amount=1000 \
        -d currency=usd \
@@ -725,14 +725,14 @@ charge=$(
 
 # verify charge status failed
 status=$(
-  curl -sSf -u $SK: $HOST/v1/charges/$charge \
+  curl -sSfg -u $SK: $HOST/v1/charges/$charge \
   | grep -oE '"status": "failed"')
 [ -n "$status" ]
 
 
 # create a pre-auth charge, observe 402 response
 code=$(
-  curl -s -o /dev/null -w "%{http_code}" \
+  curl -sg -o /dev/null -w "%{http_code}" \
        -u $SK: $HOST/v1/charges \
        -d source=$card \
        -d amount=1000 \
@@ -742,7 +742,7 @@ code=$(
 
 # create a pre-auth charge
 charge=$(
-  curl -s -u $SK: $HOST/v1/charges \
+  curl -sg -u $SK: $HOST/v1/charges \
        -d source=$card \
        -d amount=1000 \
        -d currency=usd \
@@ -751,21 +751,21 @@ charge=$(
 
 # verify charge status failed
 status=$(
-  curl -sSf -u $SK: $HOST/v1/charges/$charge \
+  curl -sSfg -u $SK: $HOST/v1/charges/$charge \
   | grep -oE '"status": "failed"')
 [ -n "$status" ]
 
 # list charges
 total_count=$(
-  curl -sSf -u $SK: $HOST/v1/charges | grep -oE '"total_count": 15')
+  curl -sSfg -u $SK: $HOST/v1/charges | grep -oE '"total_count": 15')
 [ -n "$total_count" ]
 
 total_count=$(
-  curl -sSf -u $SK: $HOST/v1/charges?customer=$cus \
+  curl -sSfg -u $SK: $HOST/v1/charges?customer=$cus \
   | grep -oE '"total_count": 6')
 [ -n "$total_count" ]
 
 total_count=$(
-  curl -sSf -u $SK: $HOST/v1/charges?customer=$cus\&created%5Bgt%5D=1588166306 \
+  curl -sSfg -u $SK: $HOST/v1/charges?customer=$cus\&created[gt]=1588166306 \
   | grep -oE '"total_count": 6')
 [ -n "$total_count" ]


### PR DESCRIPTION
### tests: Use 'curl --globoff' and [] instead of %5B%5D

Problem: very recently, Travis started to fail on commit that were
previously fine. Probably a change on their side?
It appears that on some Python version (e.g. 3.7 but not 3.8) they
double-escape `%5B` and `%5D` caracters, so they are passed as `%255B`
and `%255D`.

To avoid that, I propose to use `[` and `]` directly, and enable curl's
`-g` option (`--globoff`) so that it doesn't interpret them.

In summary now the commands are a bit clearer:

    curl -sSfg -u $SK: $HOST/v1/plans?expand[]=data.product

---

### CI: Support Python 3.8 and 3.9

And drop support on Python 3.5 and 3.6.
