### PR TITLE
Server: Dump the store after PUT POST and DELETE requests

### DIFF
--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -191,7 +191,17 @@ async def auth_middleware(request, handler):
     return await handler(request)
 
 
-app = web.Application(middlewares=[error_middleware, auth_middleware])
+@web.middleware
+async def save_store_middleware(request, handler):
+    try:
+        return await handler(request)
+    finally:
+        if request.method in ('PUT', 'POST', 'DELETE'):
+            store.dump_to_disk()
+
+
+app = web.Application(middlewares=[error_middleware, auth_middleware,
+                                   save_store_middleware])
 app.on_response_prepare.append(add_cors_headers)
 
 


### PR DESCRIPTION
Localstripe uses the `store` object to store data between localstripe executions.
But I just noticed that some TaxRate attributes are not saved properly.
It's the case for a few properties of the TaxRate object.

Reproduction:
- launch localstripe from scratch `python3 -m localstripe --from-scratch`
-
      $ curl -sSfg -u sk_test_12345: http://localhost:8420/v1/tax_rates \
        -d display_name=VAT  -d description='TVA France taux normal' \
        -d jurisdiction=FR -d percentage=20.0 -d inclusive=false
      {
        "active": true,
        "created": 1616511744,
        "description": "TVA France taux normal",
        "display_name": "VAT",
        "id": "txr_hG2CLNRGQMy35a",
        "inclusive": false,
        "jurisdiction": "FR",
        "livemode": false,
        "metadata": {},
        "object": "tax_rate",
        "percentage": 20.0
      }

- Kill localstripe
- Relaunch localstripe `python3 -m localstripe`
-
      $ curl localhost:8420/v1/tax_rates -u sk_test_12345:
      {
        "data": [
          {
            "created": 1616511409,
            "id": "txr_GDaiJpS2uF5zIj",
            "livemode": false,
            "object": "tax_rate"
          }
        ],
        "has_more": false,
        "object": "list",
        "total_count": 1,
        "url": "/v1/tax_rates"
      }

It's probably the case for other objects too.
For me the easiest solution is to always dump the store to the disk just before
answering PUT POST and DELETE HTTP requests.
