### PR TITLE
feat(invoice): Add amount_paid attribute

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1154,6 +1154,10 @@ class Invoice(StripeObject):
         return self.total
 
     @property
+    def amount_paid(self):
+        return self.amount_due if self.status == 'paid' else 0
+
+    @property
     def next_payment_attempt(self):
         if self.status in ('draft', 'open'):
             return self.date


### PR DESCRIPTION
This commit makes the assumption that invoices in localstripe are either
fully paid (amount_paid == amount_due) or not paid at all (amount_paid =
0).
This behavior can be different with real Stripe servers.

Tested with my end-to-end tests without any error.