### PR TITLE
Make tax rates properties default to empty array when unset

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1583,7 +1583,7 @@ class InvoiceItem(StripeObject):
         self.period = dict(start=period_start, end=period_end)
         self.proration = proration
         self.description = description
-        self.tax_rates = tax_rates
+        self.tax_rates = tax_rates or []
         self.metadata = metadata or {}
 
     @classmethod

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -3002,7 +3002,7 @@ class SubscriptionItem(StripeObject):
 
         self.plan = plan
         self.quantity = quantity
-        self.tax_rates = tax_rates
+        self.tax_rates = tax_rates or []
         self.metadata = metadata or {}
 
         self._subscription = subscription


### PR DESCRIPTION
**InvoiceItem: Make tax_rates property default to an empty array**

Real Stripe servers return an empty array if there is no tax rates on an
InvoiceItem object. Let's do that in localstripe too.

https://stripe.com/docs/api/invoiceitems/object#invoiceitem_object-tax_rates

---

**SubscriptionItem: Make tax_rates property default to an empty array**

Real Stripe servers return an empty array if there is no tax rates on a
SubscriptionItem object. Let's do that in localstripe too.

https://stripe.com/docs/api/subscription_items/object#subscription_item_object-tax_rates