### PR TITLE
add several list filtering improvements

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2661,6 +2661,7 @@ class Subscription(StripeObject):
 
     def __init__(self, customer=None, metadata=None, items=None,
                  trial_end=None, default_tax_rates=None,
+                 trial_from_plan=False,
                  backdate_start_date=None,
                  plan=None, quantity=None,  # legacy support
                  tax_percent=None,  # deprecated
@@ -2677,6 +2678,7 @@ class Subscription(StripeObject):
             items = [{'plan': plan, 'quantity': quantity}]
 
         trial_end = try_convert_to_int(trial_end)
+        trial_from_plan = try_convert_to_bool(trial_from_plan)
         tax_percent = try_convert_to_float(tax_percent)
         enable_incomplete_payments = try_convert_to_bool(
             enable_incomplete_payments)
@@ -2691,6 +2693,9 @@ class Subscription(StripeObject):
                     trial_end = int(time.time())
                 assert type(trial_end) is int
                 assert trial_end > 1500000000
+                assert not trial_from_plan
+            if trial_from_plan is not None:
+                assert type(trial_from_plan) is bool
             if tax_percent is not None:
                 assert default_tax_rates is None
                 assert type(tax_percent) is float
@@ -2763,6 +2768,7 @@ class Subscription(StripeObject):
         self.trial_end = trial_end
         self.trial_start = None
         self.trial_period_days = trial_period_days
+        self.trial_from_plan = trial_from_plan
         self.latest_invoice = None
         self.start_date = backdate_start_date or int(time.time())
         self.billing_cycle_anchor = billing_cycle_anchor

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -158,7 +158,7 @@ class StripeObject(object):
         if key not in store.keys():
             raise UserError(404, 'Not Found')
         del store[key]
-        return {"deleted": True, "id": id}
+        return {'deleted': True, 'id': id}
 
     @classmethod
     def _api_list_all(cls, url, limit=None, starting_after=None, **kwargs):
@@ -2300,7 +2300,7 @@ class Payout(StripeObject):
         # manually created
         self.automatic = False
         # Balance Transactions are no implemented yet so we fake one
-        self.balance_transaction = f"txn_{random_id(24)}"
+        self.balance_transaction = f'txn_{random_id(24)}'
 
         self.failure_balance_transaction = None
         self.failure_code = None

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -945,6 +945,25 @@ class Customer(StripeObject):
         return cls._api_retrieve(id).subscriptions
 
     @classmethod
+    def _api_list_sources(cls, id, object=None, **kwargs):
+        if kwargs:
+            raise UserError(400, 'Unexpected ' + ', '.join(kwargs.keys()))
+
+        try:
+            if object is not None:
+                assert type(object) is str
+                assert object in ['card', 'bank_account']
+        except AssertionError:
+            raise UserError(400, 'Bad request')
+
+        li = cls._api_retrieve(id).sources
+
+        if object is not None:
+            li._list = [i for i in li._list if i.object == object]
+
+        return li
+
+    @classmethod
     def _api_add_subscription(cls, id, **data):
         return Subscription._api_create(customer=id, **data)
 
@@ -973,6 +992,7 @@ class Customer(StripeObject):
 
 
 extra_apis.extend((
+    ('GET', '/v1/customers/{id}/sources', Customer._api_list_sources),
     ('POST', '/v1/customers/{id}/sources', Customer._api_add_source),
     # Retrieve single source by id:
     ('GET', '/v1/customers/{id}/sources/{source_id}',

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2204,6 +2204,32 @@ class Plan(StripeObject):
     def statement_descriptor(self):  # Support Stripe API <= 2018-02-05
         return Product._api_retrieve(self.product).statement_descriptor
 
+    @classmethod
+    def _api_list_all(cls, url, active=None, product=None, limit=None,
+                      starting_after=None, **kwargs):
+        if kwargs:
+            raise UserError(400, 'Unexpected ' + ', '.join(kwargs.keys()))
+
+        active = try_convert_to_bool(active)
+        try:
+            if active is not None:
+                assert type(active) is bool
+            if product is not None:
+                assert type(product) is str
+        except AssertionError:
+            raise UserError(400, 'Bad request')
+
+        li = super(Plan, cls)._api_list_all(
+            url, limit=limit, starting_after=starting_after
+        )
+
+        if active is not None:
+            li._list = [obj for obj in li._list if obj.active == active]
+        if product is not None:
+            li._list = [obj for obj in li._list if obj.product == product]
+
+        return li
+
 
 class Payout(StripeObject):
     object = 'payout'

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2350,6 +2350,28 @@ class Product(StripeObject):
 
         schedule_webhook(Event('product.created', self))
 
+    @classmethod
+    def _api_list_all(cls, url, active=None, limit=None, starting_after=None,
+                      **kwargs):
+        if kwargs:
+            raise UserError(400, 'Unexpected ' + ', '.join(kwargs.keys()))
+
+        active = try_convert_to_bool(active)
+        try:
+            if active is not None:
+                assert type(active) is bool
+        except AssertionError:
+            raise UserError(400, 'Bad request')
+
+        li = super(Product, cls)._api_list_all(
+            url, limit=limit, starting_after=starting_after
+        )
+
+        if active is not None:
+            li._list = [obj for obj in li._list if obj.active == active]
+
+        return li
+
 
 class Refund(StripeObject):
     object = 'refund'

--- a/test.sh
+++ b/test.sh
@@ -213,6 +213,11 @@ res=$(
   | grep -oE $card)
 [ -n "$res" ]
 
+# make sure cards exist in customer sources
+count=$(curl -sSfg -u $SK: $HOST/v1/customers/$cus/sources?object=card \
+        | grep -oP 'total_count": \K([0-9]+)')
+[ "$count" -eq 3 ]
+
 # delete the card
 curl -sSfg -u $SK: $HOST/v1/customers/$cus/sources/$card \
      -X DELETE
@@ -222,6 +227,11 @@ res=$(
   curl -sSfg -u $SK: $HOST/v1/customers/$cus \
   | grep -oE $card || true)
 [ -z "$res" ]
+
+# make sure cards is removed from customer sources
+count=$(curl -sSfg -u $SK: $HOST/v1/customers/$cus/sources?object=card \
+        | grep -oP 'total_count": \K([0-9]+)')
+[ "$count" -eq 2 ]
 
 # add a new card
 card=$(

--- a/test.sh
+++ b/test.sh
@@ -149,6 +149,14 @@ curl -sSfg -u $SK: $HOST/v1/products/PRODUCT1234
 
 curl -sSfg -u $SK: $HOST/v1/plans?expand[]=data.product
 
+count=$(curl -sSfg -u $SK: $HOST/v1/products?active=false \
+        | grep -oP 'total_count": \K([0-9]+)')
+[ "$count" -eq 0 ]
+
+count=$(curl -sSfg -u $SK: $HOST/v1/products?active=true \
+        | grep -oP 'total_count": \K([0-9]+)')
+[ "$count" -eq 9 ]
+
 code=$(curl -sg -o /dev/null -w '%{http_code}' -u $SK: \
             $HOST/v1/plans?expand[]=data.doesnotexist)
 [ "$code" -eq 400 ]

--- a/test.sh
+++ b/test.sh
@@ -161,6 +161,14 @@ code=$(curl -sg -o /dev/null -w '%{http_code}' -u $SK: \
             $HOST/v1/plans?expand[]=data.doesnotexist)
 [ "$code" -eq 400 ]
 
+count=$(curl -sSfg -u $SK: $HOST/v1/plans?active=false \
+        | grep -oP 'total_count": \K([0-9]+)')
+[ "$count" -eq 0 ]
+
+count=$(curl -sSfg -u $SK: $HOST/v1/plans?active=true \
+        | grep -oP 'total_count": \K([0-9]+)')
+[ "$count" -eq 6 ]
+
 curl -sSfg -u $SK: $HOST/v1/coupons \
    -d id=PARRAIN \
    -d percent_off=30 \


### PR DESCRIPTION
This PR adds several improvements to listing products, plans, customers, and subscriptions (stripe features that we use at @localstack)

* 3e46219: adds a dedicate list method for `/v1/products` to take the optional `active=true|false` keyword
* 92e1e15: same deal, adds filters for `/v1/plans`
* dfdccaf: enables the optional `object=card` filter argument to `/v1/customers/{id}/sources`
* 1423038: allows the `trial_from_plan` boolean flag for `/v1/subscriptions`

I tried to conform to the semantic commit messages i found in the history, and tried to keep the code style as close to the original code as possible.
Happy to make changes.