### PR TITLE
Invoice: Add 'collection_method' property

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1103,6 +1103,7 @@ class Invoice(StripeObject):
         self.attempt_count = 1
         self.attempted = True
         self.billing_reason = None
+        self.collection_method = 'charge_automatically'
         self.description = description
         self.discount = None
         self.ending_balance = 0


### PR DESCRIPTION
Let's add the property `collection_method` that was missing.
For the moment, it's not implemented so it's always
`charge_automatically`.

https://stripe.com/docs/api/invoices/object#invoice_object-collection_method