### PR TITLE
feat(customers): Find customers by email

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -964,6 +964,25 @@ class Customer(StripeObject):
         return li
 
     @classmethod
+    def _api_list_all(cls, url, email=None, limit=None, starting_after=None,
+                      **kwargs):
+        if kwargs:
+            raise UserError(400, 'Unexpected ' + ', '.join(kwargs.keys()))
+
+        try:
+            if email is not None:
+                assert type(email) is str
+        except AssertionError:
+            raise UserError(400, 'Bad request')
+
+        li = super(Customer, cls)._api_list_all(url, limit=limit,
+                                                starting_after=starting_after)
+        if email is not None:
+            li._list = [i for i in li._list if i.email == email]
+
+        return li
+
+    @classmethod
     def _api_add_subscription(cls, id, **data):
         return Subscription._api_create(customer=id, **data)
 

--- a/test.sh
+++ b/test.sh
@@ -16,7 +16,16 @@ curl -sSfg -u $SK: $HOST/v1/customers/$cus \
 curl -sSfg -u $SK: $HOST/v1/customers/$cus \
      -d preferred_locales[]='fr-FR' -d preferred_locales[]='es-ES'
 
+cusB=$(curl -sSfg -u $SK: $HOST/v1/customers \
+            -d email=george.carlin@example.com \
+       | grep -oE 'cus_\w+' | head -n 1)
+
+email=$(curl -sSfg -u $SK: $HOST/v1/customers?email=james.robinson@example.com \
+        | grep -oE '"email": "james.robinson@example.com",')
+[ -n "$email" ]
+
 curl -sSfg -u $SK: -X DELETE $HOST/v1/customers/$cus
+curl -sSfg -u $SK: -X DELETE $HOST/v1/customers/$cusB
 
 cus=$(curl -sSfg -u $SK: $HOST/v1/customers \
            -d description='This customer is a company' \


### PR DESCRIPTION
As described here
https://stripe.com/docs/api/customers/list#list_customers-email,
the Stripe API allows you to find one or more customers by their
email addresses by adding the query param `?email=<something>`
to the `/v1/customers` route.

Stripe doesn't care about the format of the emails we send in
the request, as long as they are strings.
If we request with an unknown address, it returns an empty list.
On the other hand, if we request with a known address, it returns
a list of customers who have this address in their email field.
So there can be several customers with the same email address.

Let's emulate this behavior.

Closes: https://github.com/adrienverge/localstripe/pull/154 https://github.com/adrienverge/localstripe/issues/153