### PR TITLE
tests: Add missing commas

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -783,17 +783,17 @@ status=$(
 
 # list charges
 total_count=$(
-  curl -sSfg -u $SK: $HOST/v1/charges | grep -oE '"total_count": 15')
+  curl -sSfg -u $SK: $HOST/v1/charges | grep -oE '"total_count": 15,')
 [ -n "$total_count" ]
 
 total_count=$(
   curl -sSfg -u $SK: $HOST/v1/charges?customer=$cus \
-  | grep -oE '"total_count": 6')
+  | grep -oE '"total_count": 6,')
 [ -n "$total_count" ]
 
 total_count=$(
   curl -sSfg -u $SK: $HOST/v1/charges?customer=$cus\&created[gt]=1588166306 \
-  | grep -oE '"total_count": 6')
+  | grep -oE '"total_count": 6,')
 [ -n "$total_count" ]
 
 no_more_events=$(curl -sSfg -u $SK: $HOST/v1/events \
@@ -914,7 +914,7 @@ card=$(curl -sSfg -u $SK: $HOST/v1/payment_methods?customer=$cus\&type=card \
 
 # trying to create a customer with a non-existant payment_method returns a 404, and doesn't create customer
 total_count=$( curl -sSfg -u $SK: $HOST/v1/customers \
-             | grep -oE '"total_count": 9')
+             | grep -oE '"total_count": 9,')
 [ -n "$total_count" ]
 
 code=$(curl -sg -o /dev/null -w '%{http_code}' -u $SK: $HOST/v1/customers \
@@ -923,5 +923,5 @@ code=$(curl -sg -o /dev/null -w '%{http_code}' -u $SK: $HOST/v1/customers \
 [ "$code" -eq 404 ]
 
 total_count=$( curl -sSfg -u $SK: $HOST/v1/customers \
-             | grep -oE '"total_count": 9')
+             | grep -oE '"total_count": 9,')
 [ -n "$total_count" ]


### PR DESCRIPTION
Everywhere in the `test.sh` file, when we use the `grep` command,
we try to catch a complete line and especially with the end comma.
Like here:
https://github.com/adrienverge/localstripe/blob/7f298f2/test.sh#L260 .

Let's add missing commas.