### PR TITLE
Publish Dockerfile in repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3
+COPY setup.py setup.cfg ./
+ADD localstripe ./localstripe
+RUN python3 setup.py sdist
+RUN pip3 install --upgrade dist/localstripe-*.tar.gz
+CMD ["localstripe"]


### PR DESCRIPTION
Being able to build easily the Docker image can be useful when testing code changes against automated tests relying on the Docker image of localstripe.