### PR TITLE
NWST-312: Cancel subscription at max payment retries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.10.11-bullseye
+
+# Install dependancies
+RUN pip install aiohttp>=2.3.2 python-dateutil>=2.6.1
+
+# Install localstripe directly
+COPY setup.cfg setup.py /tmp/
+COPY localstripe /tmp/localstripe
+RUN cd /tmp && PYTHONPATH=. python setup.py install
+
+# Make stdout logging work better
+ENV PYTHONUNBUFFERED 1
+
+CMD ["localstripe"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: build
+
+build: 
+	docker build \
+		--tag adrienverge/localstripe .

--- a/cloudbuild/main.yaml
+++ b/cloudbuild/main.yaml
@@ -1,0 +1,21 @@
+#
+# Cloudbuild config for main branch
+#
+
+# [START cloudbuild]
+steps:
+
+  - id: "build localstripe image"
+    name: "gcr.io/kaniko-project/executor:v1.6.0"
+    args: [
+        "--destination", "asia.gcr.io/${PROJECT_ID}/${_BACKEND_SERVICE_NAME}:${COMMIT_SHA}",
+        "--destination", "asia.gcr.io/${PROJECT_ID}/${_BACKEND_SERVICE_NAME}:latest",
+        "--cache=true",
+        "--cache-ttl=336h0m0s", # 2 weeks (default)
+    ]
+
+
+substitutions:
+  _BACKEND_SERVICE_NAME: localstripe
+
+# [END cloudbuild]]

--- a/localstripe/checkout.py
+++ b/localstripe/checkout.py
@@ -82,10 +82,9 @@ def checkout_pay(session, customer, payment_method):
             plan_data = {
 				"amount": product['unit_amount_decimal'],
 				"currency": product['currency'],
-				"product": product['product']
+				"product": product['product'],
+                "interval": 'month'
 			}
-            if session.mode == 'subscription':
-                plan_data['interval'] = 'month'
             plan = Plan(**plan_data)
             plans.append({
 				'plan': plan.id,

--- a/localstripe/checkout.py
+++ b/localstripe/checkout.py
@@ -1,0 +1,97 @@
+from .resources import Session, PaymentMethod, Customer, Subscription, PaymentIntent, Plan
+
+CHECKOUT_HTML = """
+<html><body>
+<form id="paymentForm" method="post">
+  <label for="cardNumber">Card Number:</label>
+  <br>
+  <input type="text" maxlength="16" minlength="16" id="cardNumber" name="cardNumber" placeholder="1234123412341234">
+  <br>
+  <input type="text" id="cardExpiry" minlength="4" maxlength="4" placeholder="MMYY" name="cardExpiry">
+  <input type="text" id="cardCvc" minlength="3" maxlength="3" placeholder="CVC" name="cardCvc">
+  <br>
+  <label for="billingName">Name on card:</label>
+  <br>
+  <input type="text" id="billingName" name="billingName">
+  <br>
+  <br>
+</form>
+<button type="submit" form="paymentForm" value="Pay">Pay</button>
+</body></html>
+"""
+
+checkout_html_apis = []
+checkout_extra_apis = []
+
+def checkout_page(request):
+    session_id = request.match_info.get('session_id', None)
+    session = Session._api_retrieve(session_id)
+    return CHECKOUT_HTML
+
+def checkout_pay(session_id, cardNumber=None, cardExpiry=None, cardCvc=None, billingName=None):
+	# Get session info
+	session = Session._api_retrieve(session_id)
+
+	# Get customer if it already exists
+	customer = None
+	if session.customer:
+		customer = Customer._api_retrieve(session.customer)
+
+	# Payment method data
+	billing_details = {
+		"name": billingName,
+		"email": customer.email if customer else session.customer_email
+	}
+	card = {
+		"number": cardNumber,
+		"cvc": cardCvc,
+		"exp_month": cardExpiry[0:2],
+		"exp_year": cardExpiry[2:4],
+	}
+	# Created payment method
+	pm = PaymentMethod(type=session.payment_method_types[0], billing_details=billing_details, card=card)
+
+	# If customer doesn't exist create a new customer and attach payment method
+	if customer is None:
+		customer = Customer(name=billingName, email=session.customer_email, payment_method=pm.id, invoice_settings={'default_payment_method': pm.id})
+
+	# Recurring payments
+	if session.mode == 'subscription':
+		# Subscriptions require items to be plans so we first create plans before creating the subscription
+		plans = []
+		for item in session.line_items:
+			product = item.get('price_data')
+			plan_data = {
+				"amount": product['unit_amount_decimal'],
+				"currency": product['currency'],
+				"product": product['product']
+			}
+			if session.mode == 'subscription':
+				plan_data['interval'] = 'month'
+			plan = Plan(**plan_data)
+			plans.append({
+				'plan': plan.id,
+				'quantity': item['quantity'],
+			})
+
+		# this should auto create an invoice and attempt to pay it
+		sub = Subscription(customer=customer.id, items=plans, metadata=session.subscription_data['metadata'])
+		session.subscription = sub.id
+
+	# One time payments
+	elif session.mode == 'payment':
+		item = session.line_items[0]['price_data']
+		pi = PaymentIntent._api_create(amount=item['unit_amount_decimal'],
+								metadata=session.payment_intent_data['metadata'],
+								currency=item['currency'],
+								customer=customer.id,
+								payment_method=pm.id,
+								confirm=True)
+		session.payment_intent = pi.id
+
+	session._complete_session()
+
+	return session.success_url.format(CHECKOUT_SESSION_ID=session_id)
+
+checkout_html_apis.append(('GET', '/c/pay/{session_id}', checkout_page))
+checkout_extra_apis.append(('POST', '/c/pay/{session_id}', checkout_pay))

--- a/localstripe/checkout.py
+++ b/localstripe/checkout.py
@@ -1,97 +1,113 @@
 from .resources import Session, PaymentMethod, Customer, Subscription, PaymentIntent, Plan
+from .errors import UserError
 
 CHECKOUT_HTML = """
 <html><body>
+<a href="{CANCEL_URL}">
+	Back
+</a>
+<br>
 <form id="paymentForm" method="post">
-  <label for="cardNumber">Card Number:</label>
-  <br>
-  <input type="text" maxlength="16" minlength="16" id="cardNumber" name="cardNumber" placeholder="1234123412341234">
-  <br>
-  <input type="text" id="cardExpiry" minlength="4" maxlength="4" placeholder="MMYY" name="cardExpiry">
-  <input type="text" id="cardCvc" minlength="3" maxlength="3" placeholder="CVC" name="cardCvc">
-  <br>
-  <label for="billingName">Name on card:</label>
-  <br>
-  <input type="text" id="billingName" name="billingName">
-  <br>
-  <br>
+	<label for="cardNumber">Card Number:</label>
+	<br>
+	<input type="text" maxlength="16" minlength="16" id="cardNumber" name="cardNumber" placeholder="1234123412341234">
+	<br>
+	<input type="text" id="cardExpiry" minlength="4" maxlength="4" placeholder="MMYY" name="cardExpiry">
+	<input type="text" id="cardCvc" minlength="3" maxlength="3" placeholder="CVC" name="cardCvc">
+	<div style="color: red">{CARD_ERROR}</div>
+	<br>
+	<label for="billingName">Name on card:</label>
+	<br>
+	<input type="text" id="billingName" name="billingName">
+	<br>
+	<br>
 </form>
 <button type="submit" form="paymentForm" value="Pay">Pay</button>
 </body></html>
 """
 
 checkout_html_apis = []
-checkout_extra_apis = []
 
-def checkout_page(request):
+def checkout_page(request, session_id, cardNumber=None, cardExpiry=None, cardCvc=None, billingName=None):
     session_id = request.match_info.get('session_id', None)
     session = Session._api_retrieve(session_id)
-    return CHECKOUT_HTML
+    html_vars = {"CANCEL_URL": session.cancel_url.format(CHECKOUT_SESSION_ID=session_id), "CARD_ERROR": ''}
+    if request.method == "POST":
+		# Get customer if it already exists
+        customer = None
+        if session.customer:
+            customer = Customer._api_retrieve(session.customer)
 
-def checkout_pay(session_id, cardNumber=None, cardExpiry=None, cardCvc=None, billingName=None):
-	# Get session info
-	session = Session._api_retrieve(session_id)
+		# Payment method data
+        billing_details = {
+			"name": billingName,
+			"email": customer.email if customer else session.customer_email
+		}
+        card = {
+			"number": cardNumber,
+			"cvc": cardCvc,
+			"exp_month": cardExpiry[0:2],
+			"exp_year": cardExpiry[2:4],
+		}
 
-	# Get customer if it already exists
-	customer = None
-	if session.customer:
-		customer = Customer._api_retrieve(session.customer)
+		# Created payment method
+        pm = PaymentMethod(type=session.payment_method_types[0], billing_details=billing_details, card=card)
 
-	# Payment method data
-	billing_details = {
-		"name": billingName,
-		"email": customer.email if customer else session.customer_email
-	}
-	card = {
-		"number": cardNumber,
-		"cvc": cardCvc,
-		"exp_month": cardExpiry[0:2],
-		"exp_year": cardExpiry[2:4],
-	}
-	# Created payment method
-	pm = PaymentMethod(type=session.payment_method_types[0], billing_details=billing_details, card=card)
+        if customer is None:
+			# This tests out payment method
+            try:
+                customer = Customer(name=billingName, email=session.customer_email, payment_method=pm.id, invoice_settings={'default_payment_method': pm.id})
+            except UserError as e:
+                if e.code == 402:
+                    html_vars["CARD_ERROR"] = "Your credit card was declined. Try paying with a debit card instead."
+        else:
+            try:
+                pm._api_attach(pm.id, customer.id)
+            except UserError as e:
+                if e.code == 402:
+                    html_vars["CARD_ERROR"] = "Your credit card was declined. Try paying with a debit card instead."
 
-	# If customer doesn't exist create a new customer and attach payment method
-	if customer is None:
-		customer = Customer(name=billingName, email=session.customer_email, payment_method=pm.id, invoice_settings={'default_payment_method': pm.id})
+        if not html_vars["CARD_ERROR"]:
+            return checkout_pay(session, customer.id, pm.id)
 
+    return CHECKOUT_HTML.format(**html_vars)
+
+def checkout_pay(session, customer, payment_method):
 	# Recurring payments
-	if session.mode == 'subscription':
+    if session.mode == 'subscription':
 		# Subscriptions require items to be plans so we first create plans before creating the subscription
-		plans = []
-		for item in session.line_items:
-			product = item.get('price_data')
-			plan_data = {
+        plans = []
+        for item in session.line_items:
+            product = item.get('price_data')
+            plan_data = {
 				"amount": product['unit_amount_decimal'],
 				"currency": product['currency'],
 				"product": product['product']
 			}
-			if session.mode == 'subscription':
-				plan_data['interval'] = 'month'
-			plan = Plan(**plan_data)
-			plans.append({
+            if session.mode == 'subscription':
+                plan_data['interval'] = 'month'
+            plan = Plan(**plan_data)
+            plans.append({
 				'plan': plan.id,
 				'quantity': item['quantity'],
 			})
 
 		# this should auto create an invoice and attempt to pay it
-		sub = Subscription(customer=customer.id, items=plans, metadata=session.subscription_data['metadata'])
-		session.subscription = sub.id
+        sub = Subscription(customer=customer, items=plans, metadata=session.subscription_data['metadata'])
+        session.subscription = sub.id
 
 	# One time payments
-	elif session.mode == 'payment':
-		item = session.line_items[0]['price_data']
-		pi = PaymentIntent._api_create(amount=item['unit_amount_decimal'],
-								metadata=session.payment_intent_data['metadata'],
-								currency=item['currency'],
-								customer=customer.id,
-								payment_method=pm.id,
-								confirm=True)
-		session.payment_intent = pi.id
+    elif session.mode == 'payment':
+        pi_data = {
+			"customer": customer,
+			"payment_method": payment_method,
+		}
+        PaymentIntent._api_update(session.payment_intent, **pi_data)
+        PaymentIntent._api_confirm(session.payment_intent)
 
-	session._complete_session()
+    session._complete_session()
 
-	return session.success_url.format(CHECKOUT_SESSION_ID=session_id)
+    return session.success_url.format(CHECKOUT_SESSION_ID=session.id)
 
 checkout_html_apis.append(('GET', '/c/pay/{session_id}', checkout_page))
-checkout_extra_apis.append(('POST', '/c/pay/{session_id}', checkout_pay))
+checkout_html_apis.append(('POST', '/c/pay/{session_id}', checkout_page))

--- a/localstripe/localstripe-v3.js
+++ b/localstripe/localstripe-v3.js
@@ -402,6 +402,10 @@ Stripe = (apiKey) => {
     },
 
     createPaymentMethod: async () => {},
+
+    redirectToCheckout: ({sessionId}) => {
+      return window.location.replace(`${LOCALSTRIPE_SOURCE}/c/pay/${sessionId}`)
+    }
   };
 };
 

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -3326,6 +3326,15 @@ class Session(StripeObject):
             print('Missing customer information')
             raise UserError(400, 'Bad request')
 
+        # Create payment intent for single payments
+        pi = None
+        if mode == "payment":
+            item = line_items[0]['price_data']
+            pi = PaymentIntent(amount=item['unit_amount_decimal'],
+                                metadata=payment_intent_data['metadata'],
+								currency=item['currency'],
+								customer=customer)
+
         # All exceptions must be raised before this point.
         super().__init__()
 
@@ -3340,6 +3349,7 @@ class Session(StripeObject):
         self.metadata = metadata or {}
         self.subscription_data = subscription_data
         self.payment_intent_data = payment_intent_data
+        self.payment_intent = pi.id if pi else None
 
     def _complete_session(self):
         schedule_webhook(Event('checkout.session.completed', self))

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2862,7 +2862,6 @@ class Subscription(StripeObject):
                     PaymentMethod._api_retrieve(
                         invoice.charge.payment_method).type == 'sepa_debit'):
                 self.status = 'active'
-        schedule_webhook(Event('customer.subscription.updated', self))
 
     def _on_initial_payment_success(self, invoice):
         self.status = 'active'


### PR DESCRIPTION
Changes:
    1. extended Subscription._on_recurring_payment_failure to cancel the subscription when max retries reached
    2. add "payment_intent.payment_failed" webhook event
    3. update invoice attributes(attempt_count, auto_advance, closed) during payment and retry failures
    4. added Invoice._api_retry_invoice and PaymentIntent._api_retry for the payment retry scenario