### PR TITLE
Balance & expand crash

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -233,7 +233,7 @@ class StripeObject(object):
                     id = obj[k]
                     cls = StripeObject._get_class_for_id(id)
                     obj[k] = cls._api_retrieve(id)._export()
-                if path is not None:
+                if path is not None and obj[k] is not None:
                     do_expand(path, obj[k])
         try:
             for path in expand:

--- a/test.sh
+++ b/test.sh
@@ -945,3 +945,9 @@ amount=$(curl -sSfg -u $SK: $HOST/v1/subscriptions \
               -d expand[]=latest_invoice \
          | grep -oP 'amount_due": \K([0-9]+)')
 [ "$amount" -eq 0 ]
+
+charge=$(curl -sSfgG -u $SK: $HOST/v1/invoices \
+              -d customer=$cus \
+              -d expand[]=data.charge.refunds \
+         | grep -oE '"charge": null,')
+[ -n "$charge" ]

--- a/test.sh
+++ b/test.sh
@@ -934,3 +934,14 @@ code=$(curl -sg -o /dev/null -w '%{http_code}' -u $SK: $HOST/v1/customers \
 total_count=$( curl -sSfg -u $SK: $HOST/v1/customers \
              | grep -oE '"total_count": 9,')
 [ -n "$total_count" ]
+
+cus=$(curl -sSfg -u $SK: $HOST/v1/customers \
+           -d balance='-20000000' \
+      | grep -oE 'cus_\w+' | head -n 1)
+
+amount=$(curl -sSfg -u $SK: $HOST/v1/subscriptions \
+              -d customer=$cus \
+              -d items[0][plan]=basique-mensuel \
+              -d expand[]=latest_invoice \
+         | grep -oP 'amount_due": \K([0-9]+)')
+[ "$amount" -eq 0 ]


### PR DESCRIPTION
### Customer: Add balance

Here is the Stripe documentation for balance at Customer creation:

Current balance, if any, being stored on the customer. If negative, the customer
has credit to apply to their next invoice. If positive, the customer has an
amount owed that will be added to their next invoice. The balance does not
refer to any unpaid invoices; it solely takes into account amounts that have
yet to be successfully applied to any invoice. This balance is only taken
into account as invoices are finalized.

I tried to make a basic implementation of it, I hope it's close enough to
what Stripe does.

----

### API: Don't crash when expanding a null object

When an Invoice doesn't have a Charge, and we
`-d expand[]=data.charge.refunds` that Invoice, the current code crash because
it cannot loop over a null Charge to find Refunds in it.

When one of the keys in the expand path is null, let's stop the recursive
exploration without crashing.