### PR TITLE
TaxID: Expand API to allow retrieving or deleting a single TaxID

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -158,7 +158,7 @@ class StripeObject(object):
         if key not in store.keys():
             raise UserError(404, 'Not Found')
         del store[key]
-        return {'deleted': True, 'id': id}
+        return DeletedObject(id, cls.object)
 
     @classmethod
     def _api_list_all(cls, url, limit=None, starting_after=None, **kwargs):
@@ -242,6 +242,14 @@ class StripeObject(object):
             raise UserError(400, 'Bad expand %s' % e)
 
         return obj
+
+
+class DeletedObject(StripeObject):
+    deleted = True
+
+    def __init__(self, id, object):
+        self.id = id
+        self.object = object
 
 
 class Balance(object):

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -261,6 +261,8 @@ def api_extra(func, url):
             data['source_id'] = request.match_info['source_id']
         if 'subscription_id' in request.match_info:
             data['subscription_id'] = request.match_info['subscription_id']
+        if 'tax_id' in request.match_info:
+            data['tax_id'] = request.match_info['tax_id']
         expand = data.pop('expand', None)
         return json_response(func(**data)._export(expand=expand))
     return f

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -238,8 +238,7 @@ def api_update(cls, url):
 def api_delete(cls, url):
     def f(request):
         id = request.match_info['id']
-        ret = cls._api_delete(id)
-        return json_response(ret if isinstance(ret, dict) else ret._export())
+        return json_response(cls._api_delete(id)._export())
     return f
 
 

--- a/test.sh
+++ b/test.sh
@@ -37,8 +37,14 @@ cus=$(curl -sSfg -u $SK: $HOST/v1/customers \
       | grep -oE 'cus_\w+' | head -n 1)
 
 curl -sSfg -u $SK: $HOST/v1/customers/$cus/tax_ids \
-     -d type=eu_vat -d value=DE123456789 \
+     -d type=eu_vat \
+     -d value=DE123456789 \
      -d expand[]=customer
+
+tax_id=$(curl -sSfg -u $SK: $HOST/v1/customers/$cus/tax_ids \
+              -d type=eu_vat \
+              -d value=BE00111222333 \
+         | grep -oE 'txi_\w+' | head -n 1)
 
 curl -sSfg -u $SK: $HOST/v1/customers/$cus?expand[]=tax_ids.data.customer
 
@@ -47,6 +53,14 @@ curl -sSfg -u $SK: $HOST/v1/customers/$cus?expand[]=subscriptions.data.items.dat
 code=$(curl -sg -o /dev/null -w '%{http_code}' -u $SK: \
        $HOST/v1/customers/$cus?expand[]=subscriptions.data.items.data.tax_ids)
 [ "$code" -eq 400 ]
+
+curl -sSfg -u $SK: $HOST/v1/customers/$cus/tax_ids/$tax_id
+
+curl -sSfg -u $SK: -X DELETE $HOST/v1/customers/$cus/tax_ids/$tax_id
+
+code=$(curl -sg -o /dev/null -w '%{http_code}' -u $SK: \
+       $HOST/v1/customers/$cus/tax_ids/$tax_id)
+[ "$code" -eq 404 ]
 
 txr1=$(curl -sSfg -u $SK: $HOST/v1/tax_rates \
             -d display_name=VAT \


### PR DESCRIPTION
### API: Add 'object' to the response on Deletion

The goal is to be closer to Stripe API. Also, create a new DeletedObject class
that will be easier to use.

---

### TaxID: Expand API to allow retrieving or deleting a single TaxID

Creating and listing TaxID have been supported for a long time, but retrieving
or deleting a single TaxID wasn't implemented, so let's change that.

Stripe doc:
- https://stripe.com/docs/api/customer_tax_ids/retrieve
- https://stripe.com/docs/api/customer_tax_ids/delete
