### PR TITLE
style: Compare Python types with `is`, not `==`

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -82,7 +82,7 @@ def try_convert_to_bool(arg):
 
 
 def try_convert_to_int(arg):
-    if type(arg) == int:
+    if type(arg) is int:
         return arg
     elif type(arg) in (str, float):
         try:
@@ -93,7 +93,7 @@ def try_convert_to_int(arg):
 
 
 def try_convert_to_float(arg):
-    if type(arg) == float:
+    if type(arg) is float:
         return arg
     elif type(arg) in (str, int):
         try:

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -181,7 +181,7 @@ async def auth_middleware(request, handler):
             data = unflatten_data(request.query)
 
         if not is_auth and accept_key_in_post_data:
-            if ('key' in data and type(data['key']) == str and
+            if ('key' in data and type(data['key']) is str and
                     data['key'].startswith('pk_')):
                 is_auth = True
 


### PR DESCRIPTION
The right way to compare primitive types in Python is to use the exact comparison `is`.

This shuts up the flake8 linter, currently complaining on master branch.