### PR TITLE
style: Use 'cls' (not 'self') in class methods

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -277,10 +277,10 @@ class Balance(object):
         schedule_webhook(Event('balance.available', self))
 
     @classmethod
-    def _api_retrieve(self):
-        obj = store.get(self.object)
+    def _api_retrieve(cls):
+        obj = store.get(cls.object)
         if obj is None:
-            return self()
+            return cls()
         return obj
 
     def _export(self, expand=None):


### PR DESCRIPTION
There is no `self` when there is no instance. Only the static class `cls` means anything in such context. As the linter says:

    N804 first argument of a classmethod should be named 'cls'