### PR TITLE
Support Python versions ≥ 3.8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.12
       - run: pip install flake8 flake8-import-order doc8 Pygments
       - run: flake8 .
       - run: doc8 README.rst
@@ -29,10 +29,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.7
           - 3.8
           - 3.9
-          - nightly
+          - 3.10
+          - 3.11
+          - 3.12
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.7 end of life was on 2023-06-27, 5 months ago.