### PR TITLE
CI: Fix tests run on Python 3.10

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,11 +29,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.8
-          - 3.9
-          - 3.10
-          - 3.11
-          - 3.12
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Commit c088710 "Support Python versions ≥ 3.8" added CI tests for Python 3.10, for YAML simplifies 3.10 to 3.1 (it's a number), which is not what we want.

Let's be explicit about 3.10 (and in the future 3.20, 3.30, etc.)