### PR TITLE
localstripe.js: Fix LOCALSTRIPE_BASE_API on dynamical load

### DIFF
--- a/localstripe/localstripe-v3.js
+++ b/localstripe/localstripe-v3.js
@@ -17,8 +17,7 @@
 
 // First, get the URL base from which this script is pulled:
 const LOCALSTRIPE_BASE_API = (function () {
-  const scripts = document.getElementsByTagName('script');
-  const src = scripts[scripts.length - 1].src;
+  const src = document.currentScript.src;
   if (src.match(/\/js\.stripe\.com\/v3\/$/)) {
     return src.replace(/\/js\.stripe\.com\/v3\/$/, '');
   } else {


### PR DESCRIPTION
This continues commit c89bb15 "API: Allow serving localstripe API from a custom URL" by simplifying the way to get localstripe server URL, and also fixes the case when `localstripe.js` is loaded dynamically (in this case, `document.getElementsByTagName('script')` references the wrong element: the calling/parent `<script>`) like this:

    let script = document.createElement('script');
    script.type = 'text/javascript';
    script.src = 'http://localhost:8420/js.stripe.com/v3/';
    document.head.appendChild(script);