### PR TITLE
TaxID: Add support for Spanish CIF

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -3276,7 +3276,13 @@ class TaxId(StripeObject):
             assert type in ('eu_vat', 'nz_gst', 'au_abn')
             assert _type(value) is str and len(value) > 10
             if country is None:
-                country = value[0:2]
+                if type == 'eu_vat':
+                    country = value[0:2]
+                elif type in ('nz_gst', 'au_abn'):
+                    country = type[0:2].upper()
+                else:
+                    # shouldn't happen because type is checked above
+                    assert False
             assert _type(country) is str
         except AssertionError:
             raise UserError(400, 'Bad request')

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -759,8 +759,12 @@ class Customer(StripeObject):
             for data in tax_id_data:
                 assert type(data) is dict
                 assert set(data.keys()) == {'type', 'value'}
-                assert data['type'] in ('eu_vat', 'nz_gst', 'au_abn')
-                assert type(data['value']) is str and len(data['value']) > 10
+                assert data['type'] in ('eu_vat', 'nz_gst', 'au_abn', 'es_cif')
+                assert type(data['value']) is str
+                if data['type'] == 'es_cif':
+                    assert len(data['value']) == 9
+                else:
+                    assert len(data['value']) > 10
             if payment_method is not None:
                 assert type(payment_method) is str
             assert type(balance) is int
@@ -928,8 +932,12 @@ class Customer(StripeObject):
             raise UserError(400, 'Unexpected ' + ', '.join(kwargs.keys()))
 
         try:
-            assert type in ('eu_vat', 'nz_gst', 'au_abn')
-            assert _type(value) is str and len(value) > 10
+            assert type in ('eu_vat', 'nz_gst', 'au_abn', 'es_cif')
+            assert _type(value) is str
+            if type == 'es_cif':
+                assert len(value) == 9
+            else:
+                assert len(value) > 10
         except AssertionError:
             raise UserError(400, 'Bad request')
 
@@ -3273,12 +3281,16 @@ class TaxId(StripeObject):
         try:
             assert _type(customer) is str
             assert customer.startswith('cus_')
-            assert type in ('eu_vat', 'nz_gst', 'au_abn')
-            assert _type(value) is str and len(value) > 10
+            assert type in ('eu_vat', 'nz_gst', 'au_abn', 'es_cif')
+            assert _type(value) is str
+            if type == 'es_cif':
+                assert len(value) == 9
+            else:
+                assert len(value) > 10
             if country is None:
                 if type == 'eu_vat':
                     country = value[0:2]
-                elif type in ('nz_gst', 'au_abn'):
+                elif type in ('nz_gst', 'au_abn', 'es_cif'):
                     country = type[0:2].upper()
                 else:
                     # shouldn't happen because type is checked above


### PR DESCRIPTION
### TaxID: Correctly set country for non 'eu_vat' taxIDs

'au_abn' and 'nz_gst' are numbers with only digits, they don't contain their
country code.
We can only guess the country from 'eu_vat' taxIDs, so let's adapt the code to
better handle AU and NZ taxIDs number.

See [the Stripe documentation] for the exact format of these two taxIDs number.

[the Stripe documentation]: https://docs.stripe.com/billing/customer/tax-ids

---

### TaxID: Add support for Spanish CIF

According to Stripe's documentation[^1], two Spanish Customer Tax IDs (`eu_vat`
& `es_cif`) are supported.

[^1]: https://docs.stripe.com/billing/customer/tax-ids#supported-tax-id-types

Let's add the support for Spain's _código de identificación fiscal_ (CIF) tax
ID.

Even if Stripe doesn't validate this type of Customer Tax ID (unlike EU
VAT)[^2], the related dashboard form input only checks if the given value's
length is 9.

[^2]: https://docs.stripe.com/billing/customer/tax-ids#validation
