### PR TITLE
Fail if no payment method on confirm

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2769,16 +2769,18 @@ class SetupIntent(StripeObject):
             pm = PaymentMethod(**payment_method_data)
             obj._attach_pm(pm)
         elif obj.payment_method is None:
-            obj.status = 'requires_payment_method'
-            obj.next_action = None
+            # If no payment method was specified upon SetupIntent creation, and
+            # none was specified in the confirm request, there's nothing to
+            # confirm. Stripe returns a 400 error in this case:
+            raise UserError(400, 'Bad request')
         else:
             obj.status = 'succeeded'
             obj.next_action = None
+
         return obj
 
     def _attach_pm(self, pm):
         self.payment_method = pm.id
-        self.payment_method_types = [pm.type]
 
         if pm._attaching_is_declined():
             self.status = 'canceled'

--- a/test.sh
+++ b/test.sh
@@ -598,7 +598,14 @@ res=$(curl -sSfg -u $SK: $HOST/v1/setup_intents -X POST)
 seti=$(echo "$res" | grep '"id"' | grep -oE 'seti_\w+' | head -n 1)
 seti_secret=$(echo $res | grep -oE 'seti_\w+_secret_\w+' | head -n 1)
 
-curl -sSfg -u $SK: $HOST/v1/setup_intents/$seti/confirm -X POST
+# If there's no payment_method in the either the SetupIntent creation or the
+# confirm call, the confirm call fails:
+code=$(curl -sg -o /dev/null -w '%{http_code}' -u $SK: \
+       -X POST $HOST/v1/setup_intents/$seti/confirm)
+[ "$code" -eq 400 ]
+
+curl -sSfg -u $SK: $HOST/v1/setup_intents/$seti/confirm -X POST \
+     -d payment_method=pm_card_visa
 
 curl -sSfg -u $SK: $HOST/v1/setup_intents/$seti/cancel -X POST
 


### PR DESCRIPTION
I added the ability to add a payment method by ID on confirm here: https://github.com/adrienverge/localstripe/pull/226

Per testing with the actual Stripe API, and common sense, we should return a 400 error if neither payment_method nor payment_method_data are supplied to the confirm request (the point of the confirm is to add a payment method, so it makes no sense to call confirm with no payment method). So I added validation and changed an old test case that seemed to be asserting a behavior unlike what Stripe actually does.

This also addresses a one-liner review comment from this PR: https://github.com/adrienverge/localstripe/pull/226

I was resetting payment_method_types within the confirm handler. Upon testing, this is not what the real Stripe API does, so I removed that recent addition.