### PR TITLE
CI: Install python3-build & add --break-system-packages for Localstripe

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,9 +41,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.pyver }}
-      - run: pip install 'pip >=23' build
+      - run: sudo apt install python3-build
       - run: python -m build
-      - run: pip install dist/localstripe-*.tar.gz
+      - run: pip install dist/localstripe-*.tar.gz --break-system-packages
       - run: python -m localstripe &
       # Wait for server to be up:
       - run: >


### PR DESCRIPTION
GitHub is rolling out `ubuntu-24.04` as the new `ubuntu-latest` on GitHub
Actions[^1]. Previously it was `ubuntu-22.04`.

There are many small breaking changes that people are complaining about in
this update[^2].

Localstripe is impacted by the fact that `pip` now fails on installing a paquet
system-wide with the following error:

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.12/README.venv for more information.
```

There are multiple solutions to this as proposed in the error message:

- Use `sudo apt install python3-...`
- Use a venv with `python -m venv venv`
- Use a venv with `pipx`
- Use the `pip` option `--break-system-packages`
- Use `ubuntu-22.04` instead of `ubuntu-latest`

For the package `build`, `python3-build` exists, so let's use it. For
`localstripe-*.tar.gz`, as we already are in an isolated container where
breaking Python is meaningless, and as there is nothing in that container that
might actually break when we install Localstripe, let's just use the option
`--break-system-packages`.

After this commit, the CI works again with `ubuntu-latest`.

[^1]: https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/
[^2]: https://github.com/actions/runner-images/issues/10636