### PR TITLE
CI: Restore previous pip install method

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,9 +41,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.pyver }}
-      - run: sudo apt install python3-build
+      - run: pip install 'pip >=23' build
       - run: python -m build
-      - run: pip install dist/localstripe-*.tar.gz --break-system-packages
+      - run: pip install dist/localstripe-*.tar.gz
       - run: python -m localstripe &
       # Wait for server to be up:
       - run: >


### PR DESCRIPTION
This reverts commit 1ad01ad "CI: Install python3-build & add --break-system-packages for Localstripe", merged 5 days ago.

Since then, the CI broke again, with errors like:

    $ python -m build
    RuntimeError: Virtual environment creation failed, executable /tmp/build-…/local/bin/python missing

I found that using our previous `pip install` commands worked. GitHub or Ubuntu maintainers probably fixed the inconveniences described by Hoël at https://github.com/adrienverge/localstripe/pull/234.