### PR TITLE
Invoice: Add `customer_email` in invoice object

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1208,6 +1208,7 @@ class Invoice(StripeObject):
         super().__init__()
 
         self.customer = customer
+        self.customer_email = cus.email
         self.subscription = subscription
         self.tax_percent = tax_percent
         self.default_tax_rates = default_tax_rates
@@ -1334,6 +1335,7 @@ class Invoice(StripeObject):
     def _finalize(self):
         assert self.status == 'draft'
         self._draft = False
+        self.customer_email = Customer._api_retrieve(self.customer).email
         self.status_transitions['finalized_at'] = int(time.time())
 
     def _on_payment_success(self):


### PR DESCRIPTION
[Stripe documentation on invoices] describes this field like this:              
                                                                                
> customer_email - nullable string                                              
>                                                                               
> The customer’s email. Until the invoice is finalized, this field will equal   
> customer.email. Once the invoice is finalized, this field will no longer be   
> updated.                                                                      
                                                                                
This is the field that should be used to know where an invoice was effectively  
sent (when using Stripe or a third-party solution to send invoices by email)    
                                                                                
Note that the current implementation only updates the field on invoice          
finalization to keep the implementation simple.                                 
                                                                                
[Stripe documentation on invoices]:                                             
https://docs.stripe.com/api/invoices/object#invoice_object-customer_email 