### PR TITLE
Taxe Rate: Use same rounding strategy as Stripe for tax amounts

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -15,6 +15,7 @@
 
 import asyncio
 from datetime import datetime, timedelta
+from decimal import Decimal, ROUND_HALF_UP
 import hashlib
 import pickle
 import random
@@ -3467,7 +3468,8 @@ class TaxRate(StripeObject):
         self.metadata = metadata or {}
 
     def _tax_amount(self, amount):
-        return {'amount': int(amount * self.percentage / 100.0),
+        decimal = Decimal(str(amount * self.percentage / 100.0))
+        return {'amount': int(decimal.quantize(Decimal('1.'), ROUND_HALF_UP)),
                 'inclusive': self.inclusive,
                 'tax_rate': self.id}
 


### PR DESCRIPTION
When computing taxes, Stripe uses the 'commercial round' strategy, meaning that 
0.5 will be rounded to 1 (when rounding to an integer) as stated here:          
https://docs.stripe.com/billing/taxes/tax-rates#rounding                        
                                                                                
Localstripe behaves differently, because to achieve rounding it casts the       
resulting `float` to an `int` with the line:                                    
                                                                                
`'amount': int(amount * self.percentage / 100.0)`                               
                                                                                
But casting to an `int` doesn't use the same rounding strategy, indeed the      
Python documentation says:                                                      
                                                                                
> For floating-point numbers, this truncates towards zero.                      
                                                                                
So this effectively rounds 0.5 to 0, which is different from Stripe behavior.   
                                                                                
This actually cause some computation differences for some combinations of tax   
rate and amount, so let's update _tax_amount rounding strategy to use the same  
one as Stripe.                                                                  
                                                                                
WARNING: This is a breaking change as it will change the computed total of an   
         invoice in some scenarios.   

--- 

Side note: I made sure that this change doesn't break our internal `11*` test suit 