### PR TITLE
Add support for the prices API.

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2551,6 +2551,40 @@ class Payout(StripeObject):
 extra_apis.append(('POST', '/v1/payouts/{id}/cancel', Payout._api_cancel))
 
 
+class Price(StripeObject):
+    object = 'price'
+    _id_prefix = 'price_'
+
+    def __init__(self, id=None, product=None, currency=None, unit_amount=None,
+                 recurring=None, **kwargs):
+        if kwargs:
+            raise UserError(400, 'Unexpected ' + ', '.join(kwargs.keys()))
+
+        assert id is None or type(id) is str
+        assert product is None or type(product) is str
+        assert currency is None or type(currency) is str
+        if unit_amount is not None:
+            unit_amount = try_convert_to_int(unit_amount)
+            assert type(unit_amount) is int and unit_amount >= 0
+        if recurring is not None:
+            assert type(recurring) is dict
+            assert 'interval' in recurring
+            assert recurring['interval'] in ('day', 'week', 'month', 'year')
+            if 'interval_count' in recurring:
+                interval_count = try_convert_to_int(recurring['interval_count'])
+                assert type(interval_count) is int and interval_count > 0
+
+        if product is not None:
+            Product._api_retrieve(product)  # to return 404 if not existant
+
+        super().__init__(id)
+
+        self.product = product
+        self.currency = currency
+        self.unit_amount = unit_amount
+        self.recurring = recurring or {}
+
+
 class Product(StripeObject):
     object = 'product'
     _id_prefix = 'prod_'

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1420,9 +1420,9 @@ class Invoice(StripeObject):
         if subscription_items:
             for si in subscription_items:
                 if 'plan' in si:
-                    Plan._api_retrieve(si['plan'])  # to return 404 if not existant
+                    Plan._api_retrieve(si['plan'])
                 if 'price' in si:
-                    Price._api_retrieve(si['price']) # to return 404 if not existant
+                    Price._api_retrieve(si['price'])
                 # To return 404 if not existant:
                 if len(si['tax_rates']):
                     [TaxRate._api_retrieve(tr) for tr in si['tax_rates']]
@@ -1733,7 +1733,7 @@ class InvoiceItem(StripeObject):
         if plan is not None:
             plan = Plan._api_retrieve(plan)  # to return 404 if not existant
         if price is not None:
-            price = Price._api_retrieve(price) # to return 404 if not existant
+            price = Price._api_retrieve(price)
         if len(tax_rates):
             # To return 404 if not existant:
             tax_rates = [TaxRate._api_retrieve(tr) for tr in tax_rates]
@@ -1798,7 +1798,10 @@ class InvoiceLineItem(StripeObject):
             self.plan = item.plan
             self.price = item.price
             self.proration = False
-            self.currency = item.plan.currency if item.plan else item.price.currency
+            self.currency = (
+                item.plan.currency if item.plan else
+                item.price.currency
+            )
             self.description = item.plan.name if item.plan else None
             self.amount = item._calculate_amount()
             self.period = item._current_period()
@@ -2600,7 +2603,8 @@ class Price(StripeObject):
             assert 'interval' in recurring
             assert recurring['interval'] in ('day', 'week', 'month', 'year')
             if 'interval_count' in recurring:
-                interval_count = try_convert_to_int(recurring['interval_count'])
+                interval_count = \
+                    try_convert_to_int(recurring['interval_count'])
                 assert type(interval_count) is int and interval_count > 0
             # TODO: Add support for "meter" and "usage_type".
         if product is not None:
@@ -3053,9 +3057,9 @@ class Subscription(StripeObject):
         Customer._api_retrieve(customer)  # to return 404 if not existant
         for item in items:
             if 'price' in item:
-                Price._api_retrieve(item['price'])  # to return 404 if not existant
+                Price._api_retrieve(item['price'])
             elif 'plan' in item:
-                Plan._api_retrieve(item['plan'])  # to return 404 if not existant
+                Plan._api_retrieve(item['plan'])
             # To return 404 if not existant:
             if len(item['tax_rates']):
                 [TaxRate._api_retrieve(tr) for tr in item['tax_rates']]
@@ -3110,7 +3114,7 @@ class Subscription(StripeObject):
     @property
     def plan(self):
         return self.items._list[0].plan
-    
+
     @property
     def price(self):
         return self.items._list[0].price
@@ -3262,11 +3266,11 @@ class Subscription(StripeObject):
             if old_plan:
                 if not items[0].get('plan'):
                     items[0]['plan'] = self.plan.id
-                Plan._api_retrieve(items[0]['plan']) # to return 404 if not existant
+                Plan._api_retrieve(items[0]['plan'])
             elif old_price:
                 if not items[0].get('price'):
                     items[0]['price'] = self.price.id
-                Price._api_retrieve(items[0]['price']) # to return 404 if not existant
+                Price._api_retrieve(items[0]['price'])
 
             # To return 404 if not existant:
             if len(items[0]['tax_rates']):
@@ -3352,8 +3356,10 @@ class Subscription(StripeObject):
             )
         ) or (
             self.price and
-            self.price.interval != old_price.interval or
-            self.price.interval_count != old_price.interval_count
+            (
+                self.price.interval != old_price.interval or
+                self.price.interval_count != old_price.interval_count
+            )
         )
         if create_an_invoice:
             self._create_invoice()

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -3310,8 +3310,8 @@ class Subscription(StripeObject):
                                 proration=True,
                                 description='Unused time',
                                 subscription=self.id,
-                                plan=old_plan.id,
-                                price=old_price.id
+                                plan=old_plan.id if old_plan else None,
+                                price=old_price.id if old_price else None,
                                 tax_rates=previous_tax_rates,
                                 customer=self.customer)
 

--- a/localstripe/server.py
+++ b/localstripe/server.py
@@ -25,8 +25,8 @@ from aiohttp import web
 
 from .resources import BalanceTransaction, Charge, Coupon, Customer, Event, \
     Invoice, InvoiceItem, PaymentIntent, PaymentMethod, Payout, Plan, \
-    Product, Refund, SetupIntent, Source, Subscription, SubscriptionItem, \
-    TaxRate, Token, extra_apis, store
+    Price, Product, Refund, SetupIntent, Source, Subscription, \
+    SubscriptionItem, TaxRate, Token, extra_apis, store
 from .errors import UserError
 from .webhooks import register_webhook
 
@@ -274,9 +274,9 @@ for method, url, func in extra_apis:
 
 
 for cls in (BalanceTransaction, Charge, Coupon, Customer, Event, Invoice,
-            InvoiceItem, PaymentIntent, PaymentMethod, Payout, Plan, Product,
-            Refund, SetupIntent, Source, Subscription, SubscriptionItem,
-            TaxRate, Token):
+            InvoiceItem, PaymentIntent, PaymentMethod, Payout, Plan, Price,
+            Product, Refund, SetupIntent, Source, Subscription,
+            SubscriptionItem, TaxRate, Token):
     for method, url, func in (
             ('POST', '/v1/' + cls.object + 's', api_create),
             ('GET', '/v1/' + cls.object + 's/{id}', api_retrieve),

--- a/test.sh
+++ b/test.sh
@@ -1279,3 +1279,24 @@ inv=$(curl -sSfg -u $SK: $HOST/v1/subscriptions \
 total=$(curl -sSfg -u $SK: $HOST/v1/invoices/$inv \
         | grep -oP '"total": \K([0-9]+)' )
 [ "$total" -eq 16383 ]
+
+# Create a price under an existing product.
+curl -sSfg -u $SK: $HOST/v1/prices \
+  -d id=price_abc001 \
+  -d currency=usd \
+  -d unit_amount=1000 \
+  -d recurring[interval]=month \
+  -d product=PRODUCT1234
+
+# Create a price and create a new product as a side-effect.
+curl -sSfg -u $SK: $HOST/v1/prices \
+  -d id=price_abc002 \
+  -d currency=usd \
+  -d unit_amount=10000 \
+  -d recurring[interval]=year \
+  -d product_data[name]=Gold\ Plan
+
+# Subscribe a user to an existing price.
+curl -sSfg -u $SK: $HOST/v1/subscriptions \
+  -d customer=$cus \
+  -d items[0][price]=price_abc001


### PR DESCRIPTION
Prices is a replacement for the legacy Plans API from Stripe. From their documentation:

> You can now model subscriptions more flexibly using the Prices API. It
> replaces the Plans API and is backwards compatible to simplify your
> migration.

This resolves #160.