### PR TITLE
Invoice: Add property 'parent'

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1333,6 +1333,14 @@ class Invoice(StripeObject):
             pi = PaymentIntent._api_retrieve(self.payment_intent)
             return pi.latest_charge
 
+    @property
+    def parent(self):
+        if self.subscription:
+            return {
+                'type': 'subscription_details',
+                'subscription_details': {'subscription': self.subscription},
+            }
+
     def _finalize(self):
         assert self.status == 'draft'
         self._draft = False


### PR DESCRIPTION
This property is supposed to be present in the newer Stripe API version "basil":
https://docs.stripe.com/api/invoices/object?api-version=2025-08-27.basil
… and supposed to be absent in the older Stripe API version "acacia": https://docs.stripe.com/api/invoices/object?api-version=2025-02-24.acacia

However, in practice it is returned by both (tested with `curl -H 'Stripe-Version: 2025-02-24.acacia` and `2025-08-27.basil`: there are differences, but `parent` is always present).

Here is what is return by the real Stripe for an invoice that is generated in the context of a subscription:

    "parent": {
      "quote_details": null,
      "subscription_details": {
        "metadata": {},
        "subscription": "sub_1SiWhdKxWWXl12QBvneJqzRY"
      },
      "type": "subscription_details"
    }

And for a draft invoice unrelated to any subscription:

    "parent": null

This commit adapts localstripe to mimick this.